### PR TITLE
Fix panel ordering bug

### DIFF
--- a/openstack_dashboard/utils/settings.py
+++ b/openstack_dashboard/utils/settings.py
@@ -54,7 +54,7 @@ def import_dashboard_config(modules):
                                 ", PANEL, PANEL_GROUP, or FEATURE defined.",
                                 submodule.__name__)
     return sorted(six.iteritems(config),
-                  key=lambda c: c[1]['__name__'].rsplit('.', 1))
+                  key=lambda c: c[1]['__name__'].rsplit('.', 1)[1])
 
 
 def update_dashboards(modules, horizon_config, installed_apps):


### PR DESCRIPTION
Panels in local/enabled are ALWAYS placed after those of /enabled, regardless of enabled file number. This fixes what appears to be an accidental bug in Horizon
