### PR TITLE
Volume Snapshot directory / Instance Tabs

### DIFF
--- a/openstack_dashboard/api/rest/cinder.py
+++ b/openstack_dashboard/api/rest/cinder.py
@@ -158,6 +158,24 @@ class VolumeType(generic.View):
 
 
 @urls.register
+class VolumeSnapshot(generic.View):
+    """API for cinder volume.
+    """
+    url_regex = r'cinder/volumesnapshots/(?P<snapshot_id>[^/]+)/$'
+
+    @rest_utils.ajax()
+    def get(self, request, snapshot_id):
+        """Get a single volume's details with the volume id.
+
+        The following get parameters may be passed in the GET
+
+        :param volume_id: the id of the volume
+
+        The result is a volume object.
+        """
+        return api.cinder.volume_snapshot_get(request, snapshot_id).to_dict()
+
+@urls.register
 class VolumeSnapshots(generic.View):
     """API for cinder volume snapshots.
     """

--- a/openstack_dashboard/static/app/core/core.module.js
+++ b/openstack_dashboard/static/app/core/core.module.js
@@ -37,6 +37,7 @@
       'horizon.app.core.metadata',
       'horizon.app.core.openstack-service-api',
       'horizon.app.core.volumes',
+      'horizon.app.core.volume-snapshots',
       'horizon.app.core.workflow',
       'horizon.framework.conf',
       'horizon.framework.util',

--- a/openstack_dashboard/static/app/core/instances/details/action-log.controller.js
+++ b/openstack_dashboard/static/app/core/instances/details/action-log.controller.js
@@ -1,0 +1,45 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function() {
+  "use strict";
+
+  angular
+    .module('horizon.app.core.instances')
+    .controller('ServerActionLogController', controller);
+
+  controller.$inject = [
+    'horizon.app.core.instances.resourceType',
+    'horizon.framework.conf.resource-type-registry.service',
+    '$scope'
+  ];
+
+  function controller(
+    resourceTypeCode,
+    registry,
+    $scope
+  ) {
+    var ctrl = this;
+
+    ctrl.server = {};
+    ctrl.resourceType = registry.getResourceType(resourceTypeCode);
+
+    $scope.descriptor.loadPromise.then(onGetResponse);
+
+    function onGetResponse(response) {
+      ctrl.server = response.data;
+    }
+  }
+
+})();

--- a/openstack_dashboard/static/app/core/instances/details/action-log.html
+++ b/openstack_dashboard/static/app/core/instances/details/action-log.html
@@ -1,0 +1,12 @@
+<div ng-controller="ServerActionLogController as ctrl">
+  <div class="row">
+    <div class="col-md-6">
+      <h3 translate>Instance Action Log</h3>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      Action Log Stuffins
+    </div>
+  </div>
+</div>

--- a/openstack_dashboard/static/app/core/instances/details/console.controller.js
+++ b/openstack_dashboard/static/app/core/instances/details/console.controller.js
@@ -1,0 +1,45 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function() {
+  "use strict";
+
+  angular
+    .module('horizon.app.core.instances')
+    .controller('ServerConsoleController', controller);
+
+  controller.$inject = [
+    'horizon.app.core.instances.resourceType',
+    'horizon.framework.conf.resource-type-registry.service',
+    '$scope'
+  ];
+
+  function controller(
+    resourceTypeCode,
+    registry,
+    $scope
+  ) {
+    var ctrl = this;
+
+    ctrl.server = {};
+    ctrl.resourceType = registry.getResourceType(resourceTypeCode);
+
+    $scope.descriptor.loadPromise.then(onGetResponse);
+
+    function onGetResponse(response) {
+      ctrl.server = response.data;
+    }
+  }
+
+})();

--- a/openstack_dashboard/static/app/core/instances/details/console.html
+++ b/openstack_dashboard/static/app/core/instances/details/console.html
@@ -1,0 +1,12 @@
+<div ng-controller="ServerConsoleController as ctrl">
+  <div class="row">
+    <div class="col-md-6">
+      <h3 translate>Instance Console</h3>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      Console Stuffins
+    </div>
+  </div>
+</div>

--- a/openstack_dashboard/static/app/core/instances/details/details.module.js
+++ b/openstack_dashboard/static/app/core/instances/details/details.module.js
@@ -56,6 +56,16 @@
         id: 'instanceDetailsLog',
         name: gettext('Log'),
         template: basePath + 'details/log.html'
+      })
+      .append({
+        id: 'instanceDetailsConsole',
+        name: gettext('Console'),
+        template: basePath + 'details/console.html'
+      })
+      .append({
+        id: 'instanceDetailsActionLog',
+        name: gettext('Action Log'),
+        template: basePath + 'details/action-log.html'
       });
 
     function loadFunction(identifier) {

--- a/openstack_dashboard/static/app/core/openstack-service-api/cinder.service.js
+++ b/openstack_dashboard/static/app/core/openstack-service-api/cinder.service.js
@@ -40,6 +40,7 @@
       getVolumeTypes: getVolumeTypes,
       getVolumeType: getVolumeType,
       getDefaultVolumeType: getDefaultVolumeType,
+      getVolumeSnapshot: getVolumeSnapshot,
       getVolumeSnapshots: getVolumeSnapshots,
       getExtensions: getExtensions,
       getQoSSpecs: getQoSSpecs,
@@ -175,6 +176,28 @@
     }
 
     // Volume Snapshots
+
+    /**
+     * @name getVolumeSnapshot
+     * @description
+     * Get a single volume snapshot.
+     *
+     * @param {Object} params
+     * Query parameters. Optional.
+     *
+     * @param {string} param.search_opts
+     * Filters to pass through the API.
+     * For example, "status": "available" will show all available volume
+     * snapshots.
+     * @returns {Object} The result of the API call
+     */
+    function getVolumeSnapshot(id) {
+      return apiService.get('/api/cinder/volumesnapshots/' + id + '/')
+        .error(function () {
+          toastService.add('error',
+                        gettext('Unable to retrieve the volume snapshots.'));
+        });
+    }
 
     /**
      * @name getVolumeSnapshots

--- a/openstack_dashboard/static/app/core/volume-snapshots/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/volume-snapshots/actions/actions.module.js
@@ -1,0 +1,53 @@
+/**
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  /**
+   * @ngdoc overview
+   * @ngname horizon.app.core.volume-snapshots.actions
+   *
+   * @description
+   * Provides all of the actions for volume snapshots.
+   */
+  angular.module('horizon.app.core.volume-snapshots.actions',
+    ['horizon.framework.conf', 'horizon.app.core'])
+    .run(run);
+
+  run.$inject = [
+    'horizon.framework.conf.resource-type-registry.service',
+    'horizon.app.core.volume-snapshots.actions.launch-instance.service',
+    'horizon.app.core.volume-snapshots.resourceType'
+  ];
+
+  function run(
+    registry,
+    launchInstanceService,
+    resourceType)
+  {
+    var instanceResourceType = registry.getResourceType(resourceType);
+    instanceResourceType.itemActions
+      .append({
+        id: 'launchInstanceService',
+        service: launchInstanceService,
+        template: {
+          text: gettext('Launch as Instance')
+        }
+      });
+  }
+
+})();

--- a/openstack_dashboard/static/app/core/volume-snapshots/actions/launch-instance.service.js
+++ b/openstack_dashboard/static/app/core/volume-snapshots/actions/launch-instance.service.js
@@ -1,0 +1,72 @@
+/**
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.app.core.volume-snapshots.actions')
+    .factory('horizon.app.core.volume-snapshots.actions.launch-instance.service', launchInstanceService);
+
+  launchInstanceService.$inject = [
+    '$q',
+    'horizon.dashboard.project.workflow.launch-instance.modal.service',
+    'horizon.framework.util.q.extensions'
+  ];
+
+  /**
+   * @ngDoc factory
+   * @name horizon.app.core.images.actions.launchInstanceService
+   *
+   * @Description
+   * Brings up the Launch Instance for image modal.
+   * On submit, launch the instance for the Image.
+   * On cancel, do nothing.
+   */
+  function launchInstanceService(
+    $q,
+    launchInstanceModal,
+    $qExtensions
+  ) {
+    var service = {
+      perform: perform,
+      allowed: allowed
+    };
+
+    return service;
+
+    //////////////
+
+    function perform(volumeSnapshot) {
+      return launchInstanceModal.open({
+        successUrl: '/project/instances',
+        'volumeSnapshotId': volumeSnapshot.id
+      }).then(onSuccess);
+
+      function onSuccess() {
+        return {
+          created: [], // ideally have the instance type/id
+          updated: [],
+          deleted: [],
+          failed: []
+        };
+      }
+    }
+
+    function allowed(volumeSnapshot) {
+      return $qExtensions.booleanAsPromise(volumeSnapshot.bootable === "true");
+    }
+  } // end of launchInstanceService
+})(); // end of IIFE

--- a/openstack_dashboard/static/app/core/volume-snapshots/details/details.module.js
+++ b/openstack_dashboard/static/app/core/volume-snapshots/details/details.module.js
@@ -1,0 +1,53 @@
+/**
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  /**
+   * @ngdoc overview
+   * @ngname horizon.app.core.volume-snapshots.details
+   *
+   * @description
+   * Provides details features for instances.
+   */
+  angular.module('horizon.app.core.volume-snapshots.details',
+    ['horizon.framework.conf', 'horizon.app.core'])
+    .run(run);
+
+  run.$inject = [
+    'horizon.app.core.volume-snapshots.resourceType',
+    'horizon.app.core.openstack-service-api.cinder',
+    'horizon.app.core.volume-snapshots.basePath',
+    'horizon.framework.conf.resource-type-registry.service'
+  ];
+
+  function run(
+    resourceType,
+    cinderApi,
+    basePath,
+    registry
+  ) {
+    registry.getResourceType(resourceType)
+      .setLoadFunction(loadFunction)
+      .setDrawerTemplateUrl(basePath + 'details/drawer.html');
+
+    function loadFunction(identifier) {
+      return cinderApi.getVolumeSnapshot(identifier);
+    }
+  }
+
+})();

--- a/openstack_dashboard/static/app/core/volume-snapshots/details/drawer.html
+++ b/openstack_dashboard/static/app/core/volume-snapshots/details/drawer.html
@@ -1,0 +1,11 @@
+<div class="row">
+  <div class="col-md-6">
+    <dl class="dl-horizontal">
+      <dt translate>Description</dt><dd>{$ item.description $}</dd>
+    </dl>
+  </div>
+  <div class="col-md-6">
+    <dl class="dl-horizontal">
+    </dl>
+  </div>
+</div>

--- a/openstack_dashboard/static/app/core/volume-snapshots/volume-snapshots.module.js
+++ b/openstack_dashboard/static/app/core/volume-snapshots/volume-snapshots.module.js
@@ -1,0 +1,53 @@
+/**
+ * (c) Copyright 2015 Hewlett-Packard Development Company, L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  /**
+   * @ngdoc overview
+   * @ngname horizon.app.core.volume-snapshots
+   *
+   * @description
+   * Provides all of the services and widgets required
+   * to support and display instances related content.
+   */
+  angular
+    .module('horizon.app.core.volume-snapshots', ['ngRoute',
+      'horizon.app.core.volume-snapshots.actions', 'horizon.app.core.volume-snapshots.details'])
+    .constant('horizon.app.core.volume-snapshots.resourceType', 'OS::Cinder::Snapshot')
+    .config(config)
+    .run(run);
+
+  config.$inject = [ '$provide', '$windowProvider' ];
+
+  function config($provide, $windowProvider) {
+    var path = $windowProvider.$get().STATIC_URL + 'app/core/volume-snapshots/';
+    $provide.constant('horizon.app.core.volume-snapshots.basePath', path);
+  }
+
+  run.$inject = [
+    'horizon.framework.conf.resource-type-registry.service',
+    'horizon.app.core.volume-snapshots.resourceType'
+  ];
+
+  function run(registry, resourceType) {
+    registry.getResourceType(resourceType, {
+      names: [gettext('Volume Snapshot'), gettext('Volume Snapshots')]
+    });
+  }
+
+})();


### PR DESCRIPTION
This is just some buildout work I did today, to add the Volume Snapshot skeleton since it has the last remaining action, and Added Instance Details tabs so it looks similar to the existing Horizon Instance details.
