### PR TITLE
WIP: Django-routed panels

### DIFF
--- a/openstack_dashboard/dashboards/project/ngdetails/index.html
+++ b/openstack_dashboard/dashboards/project/ngdetails/index.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans "Images" %}{% endblock %}
+
+{% block page_header %}
+{% endblock %}
+
+{% block ng_route_base %}
+  <base href="{{ WEBROOT }}">
+{% endblock %}
+
+{% block main %}
+  <div ng-view></div>
+{% endblock %}

--- a/openstack_dashboard/dashboards/project/ngdetails/panel.py
+++ b/openstack_dashboard/dashboards/project/ngdetails/panel.py
@@ -1,0 +1,22 @@
+#    (c) Copyright 2015 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from django.utils.translation import ugettext_lazy as _
+
+import horizon
+
+
+class NGDetails(horizon.Panel):
+    name = _("Details")
+    slug = 'ngdetails'

--- a/openstack_dashboard/dashboards/project/ngdetails/templates/ngdetails/index.html
+++ b/openstack_dashboard/dashboards/project/ngdetails/templates/ngdetails/index.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans "Images" %}{% endblock %}
+
+{% block page_header %}
+{% endblock %}
+
+{% block ng_route_base %}
+  <base href="{{ WEBROOT }}">
+{% endblock %}
+
+{% block main %}
+  <div ng-view></div>
+{% endblock %}

--- a/openstack_dashboard/dashboards/project/ngdetails/urls.py
+++ b/openstack_dashboard/dashboards/project/ngdetails/urls.py
@@ -1,0 +1,24 @@
+#    (c) Copyright 2015 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from django.conf.urls import patterns
+from django.conf.urls import url
+
+from openstack_dashboard.dashboards.project.ngdetails import views
+
+
+urlpatterns = patterns(
+    'openstack_dashboard.dashboards.project.ngdetails.views',
+    url('', views.IndexView.as_view(), name='index'),
+)

--- a/openstack_dashboard/dashboards/project/ngdetails/views.py
+++ b/openstack_dashboard/dashboards/project/ngdetails/views.py
@@ -1,0 +1,19 @@
+#    (c) Copyright 2015 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from django.views import generic
+
+
+class IndexView(generic.TemplateView):
+    template_name = 'project/ngdetails/index.html'

--- a/openstack_dashboard/enabled/_1070_project_ng_details_panel.py
+++ b/openstack_dashboard/enabled/_1070_project_ng_details_panel.py
@@ -1,0 +1,30 @@
+# (c) Copyright 2015 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# The slug of the dashboard the PANEL associated with. Required.
+PANEL_DASHBOARD = 'project'
+
+# The slug of the panel group the PANEL is associated with.
+# If you want the panel to show up without a panel group,
+# use the panel group "default".
+PANEL_GROUP = 'compute'
+
+# The slug of the panel to be added to HORIZON_CONFIG. Required.
+PANEL = 'ngdetails'
+
+# If set to True, this settings file will not be added to the settings.
+DISABLED = False
+
+# Python panel class of the PANEL to be added.
+ADD_PANEL = 'openstack_dashboard.dashboards.project.ngdetails.panel.NGDetails'

--- a/openstack_dashboard/static/app/core/core.module.js
+++ b/openstack_dashboard/static/app/core/core.module.js
@@ -56,7 +56,7 @@
     var path = $windowProvider.$get().STATIC_URL + 'app/core/';
     $provide.constant('horizon.app.core.basePath', path);
     $routeProvider
-      .when('/details/:type/:path', {
+      .when('/project/ngdetails/:type/:path', {
         templateUrl: $windowProvider.$get().STATIC_URL +
           'framework/widgets/details/routed-details-view.html'
       })

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -118,7 +118,7 @@
             id: 'name',
             priority: 1,
             sortDefault: true,
-            template: '<a ng-href="{$ \'details/OS::Glance::Image/\' + item.id $}">{$ item.name $}</a>'
+            template: '<a ng-href="{$ \'project/ngdetails/OS::Glance::Image/\' + item.id $}">{$ item.name $}</a>'
       })
       .append({
             id: 'type',

--- a/openstack_dashboard/static/app/core/instances/instances.module.js
+++ b/openstack_dashboard/static/app/core/instances/instances.module.js
@@ -70,7 +70,7 @@
         id: 'name',
         priority: 1,
         sortDefault: true,
-        template: '<a ng-href="{$ \'details/OS::Nova::Server/\' + item.id $}">{$ item.name $}</a>'
+        template: '<a ng-href="{$ \'project/ngdetails/OS::Nova::Server/\' + item.id $}">{$ item.name $}</a>'
       })
       .append({
         id: 'image_name',


### PR DESCRIPTION
This patch demonstrates how you can make the generic details view routable.

Change-Id: I00204e36c90420717758d8beea44fecaaf1cbfee
Partially-Implements: blueprint angularize-images-table

PROBLEMS: This shows up as a panel in the nav.
NOTE: This changes the route to project/ngdetails, since I couldn't find the right way to provide a view at 'details/', and this needs to be reflected on the searchlight-ui (there is a similar patch up there)
