### PR TITLE
Start/Stop server

### DIFF
--- a/horizon/static/framework/util/actions/action-promise.service.js
+++ b/horizon/static/framework/util/actions/action-promise.service.js
@@ -1,0 +1,69 @@
+/**
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.framework.util.actions')
+    .factory('horizon.framework.util.actions.action-promise.service', factory);
+
+
+  function factory() {
+
+    
+    return {
+      getResolved: getResolved
+    };
+
+    function getResolved() {
+      return new ResolvedObject();
+    }
+
+    function ResolvedObject() {
+      this.result = {
+        created: [],
+        updated: [],
+        deleted: [],
+        failed: []
+      };
+      this.created = created;
+      this.updated = updated;
+      this.deleted = deleted;
+      this.failed = failed;
+
+      function created(type, id) {
+        this.result.created.push({type: type, id: id});
+        return this;
+      }
+
+      function updated(type, id) {
+        this.result.updated.push({type: type, id: id});
+        return this;
+      }
+
+      function deleted(type, id) {
+        this.result.deleted.push({type: type, id: id});
+        return this;
+      }
+
+      function failed(type, id) {
+        this.result.failed.push({type: type, id: id});
+        return this;
+      }
+    }
+    
+  }
+})();

--- a/horizon/static/framework/util/actions/action-promise.service.js
+++ b/horizon/static/framework/util/actions/action-promise.service.js
@@ -25,14 +25,14 @@
 
     
     return {
-      getResolved: getResolved
+      getActionResult: getActionResult
     };
 
-    function getResolved() {
-      return new ResolvedObject();
+    function getActionResult() {
+      return new ActionResult();
     }
 
-    function ResolvedObject() {
+    function ActionResult() {
       this.result = {
         created: [],
         updated: [],

--- a/openstack_dashboard/api/rest/nova.py
+++ b/openstack_dashboard/api/rest/nova.py
@@ -282,6 +282,10 @@ class Server(generic.View):
           return api.nova.server_suspend(request, server_id)
         elif operation == 'resume':
           return api.nova.server_resume(request, server_id)
+        elif operation == 'hard_reboot':
+          return api.nova.server_reboot(request, server_id, False)
+        elif operation == 'soft_reboot':
+          return api.nova.server_reboot(request, server_id, True)
 
     @rest_utils.ajax()
     def delete(self, request, server_id):

--- a/openstack_dashboard/api/rest/nova.py
+++ b/openstack_dashboard/api/rest/nova.py
@@ -274,6 +274,10 @@ class Server(generic.View):
           return api.nova.server_stop(request, server_id)
         elif operation == 'start':
           return api.nova.server_start(request, server_id)
+        elif operation == 'pause':
+          return api.nova.server_pause(request, server_id)
+        elif operation == 'unpause':
+          return api.nova.server_unpause(request, server_id)
 
     @rest_utils.ajax()
     def delete(self, request, server_id):

--- a/openstack_dashboard/api/rest/nova.py
+++ b/openstack_dashboard/api/rest/nova.py
@@ -265,6 +265,16 @@ class Server(generic.View):
         """
         return api.nova.server_get(request, server_id).to_dict()
 
+    @rest_utils.ajax(data_required=True)
+    def post(self, request, server_id):
+        """Perform a change to a server
+        """
+        operation = request.DATA.get('operation', 'none')
+        if operation == 'stop':
+          return api.nova.server_stop(request, server_id)
+        elif operation == 'start':
+          return api.nova.server_start(request, server_id)
+
     @rest_utils.ajax()
     def delete(self, request, server_id):
         api.nova.server_delete(request, server_id)

--- a/openstack_dashboard/api/rest/nova.py
+++ b/openstack_dashboard/api/rest/nova.py
@@ -278,6 +278,10 @@ class Server(generic.View):
           return api.nova.server_pause(request, server_id)
         elif operation == 'unpause':
           return api.nova.server_unpause(request, server_id)
+        elif operation == 'suspend':
+          return api.nova.server_suspend(request, server_id)
+        elif operation == 'resume':
+          return api.nova.server_resume(request, server_id)
 
     @rest_utils.ajax()
     def delete(self, request, server_id):

--- a/openstack_dashboard/dashboards/project/ngdetails/index.html
+++ b/openstack_dashboard/dashboards/project/ngdetails/index.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans "Images" %}{% endblock %}
+
+{% block page_header %}
+{% endblock %}
+
+{% block ng_route_base %}
+  <base href="{{ WEBROOT }}">
+{% endblock %}
+
+{% block main %}
+  <div ng-view></div>
+{% endblock %}

--- a/openstack_dashboard/dashboards/project/ngdetails/panel.py
+++ b/openstack_dashboard/dashboards/project/ngdetails/panel.py
@@ -1,0 +1,22 @@
+#    (c) Copyright 2015 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from django.utils.translation import ugettext_lazy as _
+
+import horizon
+
+
+class NGDetails(horizon.Panel):
+    name = _("Details")
+    slug = 'ngdetails'

--- a/openstack_dashboard/dashboards/project/ngdetails/templates/ngdetails/index.html
+++ b/openstack_dashboard/dashboards/project/ngdetails/templates/ngdetails/index.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans "Images" %}{% endblock %}
+
+{% block page_header %}
+{% endblock %}
+
+{% block ng_route_base %}
+  <base href="{{ WEBROOT }}">
+{% endblock %}
+
+{% block main %}
+  <div ng-view></div>
+{% endblock %}

--- a/openstack_dashboard/dashboards/project/ngdetails/urls.py
+++ b/openstack_dashboard/dashboards/project/ngdetails/urls.py
@@ -1,0 +1,24 @@
+#    (c) Copyright 2015 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from django.conf.urls import patterns
+from django.conf.urls import url
+
+from openstack_dashboard.dashboards.project.ngdetails import views
+
+
+urlpatterns = patterns(
+    'openstack_dashboard.dashboards.project.ngdetails.views',
+    url('', views.IndexView.as_view(), name='index'),
+)

--- a/openstack_dashboard/dashboards/project/ngdetails/views.py
+++ b/openstack_dashboard/dashboards/project/ngdetails/views.py
@@ -1,0 +1,19 @@
+#    (c) Copyright 2015 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from django.views import generic
+
+
+class IndexView(generic.TemplateView):
+    template_name = 'project/ngdetails/index.html'

--- a/openstack_dashboard/dashboards/project/ngimage/panel.py
+++ b/openstack_dashboard/dashboards/project/ngimage/panel.py
@@ -18,5 +18,5 @@ import horizon
 
 
 class NGImage(horizon.Panel):
-    name = _("l'Image")
+    name = _("Images (gen.)")
     slug = 'ngimage'

--- a/openstack_dashboard/dashboards/project/nginstance/panel.py
+++ b/openstack_dashboard/dashboards/project/nginstance/panel.py
@@ -18,5 +18,5 @@ import horizon
 
 
 class NGInstance(horizon.Panel):
-    name = _("Instances")
+    name = _("Instances (gen.)")
     slug = 'nginstance'

--- a/openstack_dashboard/enabled/_1070_project_ng_details_panel.py
+++ b/openstack_dashboard/enabled/_1070_project_ng_details_panel.py
@@ -1,0 +1,30 @@
+# (c) Copyright 2015 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# The slug of the dashboard the PANEL associated with. Required.
+PANEL_DASHBOARD = 'project'
+
+# The slug of the panel group the PANEL is associated with.
+# If you want the panel to show up without a panel group,
+# use the panel group "default".
+PANEL_GROUP = 'compute'
+
+# The slug of the panel to be added to HORIZON_CONFIG. Required.
+PANEL = 'ngdetails'
+
+# If set to True, this settings file will not be added to the settings.
+DISABLED = False
+
+# Python panel class of the PANEL to be added.
+ADD_PANEL = 'openstack_dashboard.dashboards.project.ngdetails.panel.NGDetails'

--- a/openstack_dashboard/static/app/core/core.module.js
+++ b/openstack_dashboard/static/app/core/core.module.js
@@ -56,7 +56,7 @@
     var path = $windowProvider.$get().STATIC_URL + 'app/core/';
     $provide.constant('horizon.app.core.basePath', path);
     $routeProvider
-      .when('/details/:type/:path', {
+      .when('/project/ngdetails/:type/:path', {
         templateUrl: $windowProvider.$get().STATIC_URL +
           'framework/widgets/details/routed-details-view.html'
       })

--- a/openstack_dashboard/static/app/core/core.module.js
+++ b/openstack_dashboard/static/app/core/core.module.js
@@ -35,6 +35,7 @@
       'horizon.app.core.images',
       'horizon.app.core.instances',
       'horizon.app.core.metadata',
+      'horizon.app.core.networks',
       'horizon.app.core.openstack-service-api',
       'horizon.app.core.volumes',
       'horizon.app.core.volume-snapshots',

--- a/openstack_dashboard/static/app/core/images/images.module.js
+++ b/openstack_dashboard/static/app/core/images/images.module.js
@@ -118,7 +118,7 @@
             id: 'name',
             priority: 1,
             sortDefault: true,
-            template: '<a ng-href="{$ \'details/OS::Glance::Image/\' + item.id $}">{$ item.name $}</a>'
+            template: '<a ng-href="{$ \'project/ngdetails/OS::Glance::Image/\' + item.id $}">{$ item.name $}</a>'
       })
       .append({
             id: 'type',

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -30,12 +30,14 @@
 
   run.$inject = [
     'horizon.framework.conf.resource-type-registry.service',
+    'horizon.framework.util.actions.redirect-action.service',
     'horizon.app.core.images.actions.launch-instance.service',
     'horizon.app.core.instances.resourceType'
   ];
 
   function run(
     registry,
+    redirectService,
     launchInstanceService,
     instanceResourceTypeCode)
   {
@@ -48,6 +50,18 @@
           text: gettext('Create Instance')
         }
       });
+    instanceResourceType.itemActions
+      .append({
+        id: 'legacyService',
+        service: redirectService(legacyPath),
+        template: {
+          text: gettext('Legacy Details...')
+        }
+      });
+
+   function legacyPath(item) {
+     return 'project/instances/' + item.id + '/';
+   }
   }
 
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -33,6 +33,8 @@
     'horizon.framework.util.actions.redirect-action.service',
     'horizon.app.core.images.actions.launch-instance.service',
     'horizon.app.core.instances.actions.delete-instance.service',
+    'horizon.app.core.instances.actions.start.service',
+    'horizon.app.core.instances.actions.stop.service',
     'horizon.app.core.instances.resourceType'
   ];
 
@@ -41,6 +43,8 @@
     redirectService,
     launchInstanceService,
     deleteService,
+    startService,
+    stopService,
     instanceResourceTypeCode)
   {
     var instanceResourceType = registry.getResourceType(instanceResourceTypeCode);
@@ -66,6 +70,20 @@
         template: {
           text: gettext('Delete'),
           type: "delete"
+        }
+      })
+      .append({
+        id: 'startService',
+        service: startService,
+        template: {
+          text: gettext('Start')
+        }
+      })
+      .append({
+        id: 'stopService',
+        service: stopService,
+        template: {
+          text: gettext('Stop')
         }
       });
 

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -37,6 +37,8 @@
     'horizon.app.core.instances.actions.unpause.service',
     'horizon.app.core.instances.actions.suspend.service',
     'horizon.app.core.instances.actions.resume.service',
+    'horizon.app.core.instances.actions.hard-reboot.service',
+    'horizon.app.core.instances.actions.soft-reboot.service',
     'horizon.app.core.instances.actions.start.service',
     'horizon.app.core.instances.actions.stop.service',
     'horizon.app.core.instances.resourceType'
@@ -51,6 +53,8 @@
     unpauseService,
     suspendService,
     resumeService,
+    hardRebootService,
+    softRebootService,
     startService,
     stopService,
     instanceResourceTypeCode)
@@ -91,6 +95,20 @@
         service: resumeService,
         template: {
           text: gettext('Resume')
+        }
+      })
+      .append({
+        id: 'hardRebootService',
+        service: hardRebootService,
+        template: {
+          text: gettext('Hard Reboot')
+        }
+      })
+      .append({
+        id: 'softRebootService',
+        service: softRebootService,
+        template: {
+          text: gettext('Soft Reboot')
         }
       })
       .append({

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -57,13 +57,6 @@
 
     instanceResourceType.itemActions
       .append({
-        id: 'deleteService',
-        service: deleteService,
-        template: {
-          text: gettext('Delete')
-        }
-      })
-      .append({
         id: 'startService',
         service: startService,
         template: {
@@ -75,6 +68,14 @@
         service: stopService,
         template: {
           text: gettext('Stop')
+        }
+      })
+      .append({
+        id: 'deleteService',
+        service: deleteService,
+        template: {
+          type: 'delete',
+          text: gettext('Delete')
         }
       });
   }

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -1,5 +1,5 @@
 /**
- * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -32,6 +32,8 @@
     'horizon.framework.conf.resource-type-registry.service',
     'horizon.app.core.images.actions.launch-instance.service',
     'horizon.app.core.instances.actions.delete-instance.service',
+    'horizon.app.core.instances.actions.start.service',
+    'horizon.app.core.instances.actions.stop.service',
     'horizon.app.core.instances.resourceType'
   ];
 
@@ -39,6 +41,8 @@
     registry,
     launchInstanceService,
     deleteService,
+    startService,
+    stopService,
     instanceResourceTypeCode)
   {
     var instanceResourceType = registry.getResourceType(instanceResourceTypeCode);
@@ -57,6 +61,20 @@
         service: deleteService,
         template: {
           text: gettext('Delete')
+        }
+      })
+      .append({
+        id: 'startService',
+        service: startService,
+        template: {
+          text: gettext('Start')
+        }
+      })
+      .append({
+        id: 'stopService',
+        service: stopService,
+        template: {
+          text: gettext('Stop')
         }
       });
   }

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -34,6 +34,8 @@
     'horizon.app.core.instances.actions.delete-instance.service',
     'horizon.app.core.instances.actions.pause.service',
     'horizon.app.core.instances.actions.unpause.service',
+    'horizon.app.core.instances.actions.suspend.service',
+    'horizon.app.core.instances.actions.resume.service',
     'horizon.app.core.instances.actions.start.service',
     'horizon.app.core.instances.actions.stop.service',
     'horizon.app.core.instances.resourceType'
@@ -45,6 +47,8 @@
     deleteService,
     pauseService,
     unpauseService,
+    suspendService,
+    resumeService,
     startService,
     stopService,
     instanceResourceTypeCode)
@@ -72,6 +76,20 @@
         service: unpauseService,
         template: {
           text: gettext('Unpause')
+        }
+      })
+      .append({
+        id: 'suspendService',
+        service: suspendService,
+        template: {
+          text: gettext('Suspend')
+        }
+      })
+      .append({
+        id: 'resumeService',
+        service: resumeService,
+        template: {
+          text: gettext('Resume')
         }
       })
       .append({

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -32,6 +32,8 @@
     'horizon.framework.conf.resource-type-registry.service',
     'horizon.app.core.images.actions.launch-instance.service',
     'horizon.app.core.instances.actions.delete-instance.service',
+    'horizon.app.core.instances.actions.pause.service',
+    'horizon.app.core.instances.actions.unpause.service',
     'horizon.app.core.instances.actions.start.service',
     'horizon.app.core.instances.actions.stop.service',
     'horizon.app.core.instances.resourceType'
@@ -41,6 +43,8 @@
     registry,
     launchInstanceService,
     deleteService,
+    pauseService,
+    unpauseService,
     startService,
     stopService,
     instanceResourceTypeCode)
@@ -56,6 +60,20 @@
       });
 
     instanceResourceType.itemActions
+      .append({
+        id: 'pauseService',
+        service: pauseService,
+        template: {
+          text: gettext('Pause')
+        }
+      })
+      .append({
+        id: 'unpauseService',
+        service: unpauseService,
+        template: {
+          text: gettext('Unpause')
+        }
+      })
       .append({
         id: 'startService',
         service: startService,

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -36,6 +36,8 @@
     'horizon.app.core.instances.actions.unpause.service',
     'horizon.app.core.instances.actions.suspend.service',
     'horizon.app.core.instances.actions.resume.service',
+    'horizon.app.core.instances.actions.hard-reboot.service',
+    'horizon.app.core.instances.actions.soft-reboot.service',
     'horizon.app.core.instances.actions.start.service',
     'horizon.app.core.instances.actions.stop.service',
     'horizon.app.core.instances.resourceType'
@@ -49,6 +51,8 @@
     unpauseService,
     suspendService,
     resumeService,
+    hardRebootService,
+    softRebootService,
     startService,
     stopService,
     instanceResourceTypeCode)
@@ -90,6 +94,20 @@
         service: resumeService,
         template: {
           text: gettext('Resume')
+        }
+      })
+      .append({
+        id: 'hardRebootService',
+        service: hardRebootService,
+        template: {
+          text: gettext('Hard Reboot')
+        }
+      })
+      .append({
+        id: 'softRebootService',
+        service: softRebootService,
+        template: {
+          text: gettext('Soft Reboot')
         }
       })
       .append({

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -33,6 +33,8 @@
     'horizon.framework.util.actions.redirect-action.service',
     'horizon.app.core.images.actions.launch-instance.service',
     'horizon.app.core.instances.actions.delete-instance.service',
+    'horizon.app.core.instances.actions.pause.service',
+    'horizon.app.core.instances.actions.unpause.service',
     'horizon.app.core.instances.actions.start.service',
     'horizon.app.core.instances.actions.stop.service',
     'horizon.app.core.instances.resourceType'
@@ -43,6 +45,8 @@
     redirectService,
     launchInstanceService,
     deleteService,
+    pauseService,
+    unpauseService,
     startService,
     stopService,
     instanceResourceTypeCode)
@@ -57,6 +61,20 @@
         }
       });
     instanceResourceType.itemActions
+      .append({
+        id: 'pauseService',
+        service: pauseService,
+        template: {
+          text: gettext('Pause')
+        }
+      })
+      .append({
+        id: 'unpauseService',
+        service: unpauseService,
+        template: {
+          text: gettext('Unpause')
+        }
+      })
       .append({
         id: 'startService',
         service: startService,

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -58,21 +58,6 @@
       });
     instanceResourceType.itemActions
       .append({
-        id: 'legacyService',
-        service: redirectService(legacyPath),
-        template: {
-          text: gettext('Legacy Details...')
-        }
-      })
-      .append({
-        id: 'deleteService',
-        service: deleteService,
-        template: {
-          text: gettext('Delete'),
-          type: "delete"
-        }
-      })
-      .append({
         id: 'startService',
         service: startService,
         template: {
@@ -84,6 +69,21 @@
         service: stopService,
         template: {
           text: gettext('Stop')
+        }
+      })
+      .append({
+        id: 'legacyService',
+        service: redirectService(legacyPath),
+        template: {
+          text: gettext('Legacy Details...')
+        }
+      })
+      .append({
+        id: 'deleteService',
+        service: deleteService,
+        template: {
+          type: 'delete',
+          text: gettext('Delete')
         }
       });
 

--- a/openstack_dashboard/static/app/core/instances/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/instances/actions/actions.module.js
@@ -35,6 +35,8 @@
     'horizon.app.core.instances.actions.delete-instance.service',
     'horizon.app.core.instances.actions.pause.service',
     'horizon.app.core.instances.actions.unpause.service',
+    'horizon.app.core.instances.actions.suspend.service',
+    'horizon.app.core.instances.actions.resume.service',
     'horizon.app.core.instances.actions.start.service',
     'horizon.app.core.instances.actions.stop.service',
     'horizon.app.core.instances.resourceType'
@@ -47,6 +49,8 @@
     deleteService,
     pauseService,
     unpauseService,
+    suspendService,
+    resumeService,
     startService,
     stopService,
     instanceResourceTypeCode)
@@ -73,6 +77,20 @@
         service: unpauseService,
         template: {
           text: gettext('Unpause')
+        }
+      })
+      .append({
+        id: 'suspendService',
+        service: suspendService,
+        template: {
+          text: gettext('Suspend')
+        }
+      })
+      .append({
+        id: 'resumeService',
+        service: resumeService,
+        template: {
+          text: gettext('Resume')
         }
       })
       .append({

--- a/openstack_dashboard/static/app/core/instances/actions/delete-instance.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/delete-instance.service.js
@@ -94,7 +94,7 @@
         ]);
       }
       else {
-        return policy.ifAllowed({ rules: [['instance', 'delete_instance']] });
+        return policy.ifAllowed({ rules: [['compute', 'compute:delete']] });
       }
     }
 

--- a/openstack_dashboard/static/app/core/instances/actions/delete-instance.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/delete-instance.service.js
@@ -70,7 +70,7 @@
     function initScope(newScope) {
       scope = newScope;
       context = { };
-      deletePromise = policy.ifAllowed({rules: [['instance', 'delete_instance']]});
+      deletePromise = policy.ifAllowed({rules: [['compute', 'compute:delete']]});
     }
 
     function perform(items) {

--- a/openstack_dashboard/static/app/core/instances/actions/delete-instance.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/delete-instance.service.js
@@ -1,4 +1,6 @@
 /**
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use self file except in compliance with the License. You may obtain
  * a copy of the License at

--- a/openstack_dashboard/static/app/core/instances/actions/delete-instance.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/delete-instance.service.js
@@ -26,6 +26,7 @@
     'horizon.app.core.openstack-service-api.nova',
     'horizon.app.core.openstack-service-api.userSession',
     'horizon.app.core.openstack-service-api.policy',
+    'horizon.app.core.instances.actions.instance-status.service',
     'horizon.framework.util.i18n.gettext',
     'horizon.framework.util.q.extensions',
     'horizon.framework.widgets.modal.deleteModalService',
@@ -49,6 +50,7 @@
     nova,
     userSessionService,
     policy,
+    statusService,
     gettext,
     $qExtensions,
     deleteModal,
@@ -164,7 +166,7 @@
     }
 
     function notDeleted(instance) {
-      return $qExtensions.booleanAsPromise(instance.status !== 'deleted');
+      return $qExtensions.booleanAsPromise(!statusService.isDeleting(instance));
     }
 
     function notProtected(instance) {

--- a/openstack_dashboard/static/app/core/instances/actions/generic-simple.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/generic-simple.service.js
@@ -52,14 +52,13 @@
   ) {
 
 
-    return function(conf) {
+    return function(config) {
       var policyPromise;
       var service = {
         initScope: initScope,
         allowed: allowed,
         perform: perform
       };
-      var config = conf;
       return service;
 
       function initScope() {
@@ -93,6 +92,6 @@
           return $qExtensions.booleanAsPromise(config.validState(instance));
         }
       }
-    }
+    };
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/generic-simple.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/generic-simple.service.js
@@ -1,4 +1,6 @@
 /**
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use self file except in compliance with the License. You may obtain
  * a copy of the License at

--- a/openstack_dashboard/static/app/core/instances/actions/generic-simple.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/generic-simple.service.js
@@ -73,7 +73,7 @@
 
         function onSuccess() {
           waitSpinner.hideModalSpinner();
-          return actionPromiseService.getResolved()
+          return actionPromiseService.getActionResult()
             .updated(instanceResourceType, item.id)
             .result;
         }

--- a/openstack_dashboard/static/app/core/instances/actions/generic-simple.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/generic-simple.service.js
@@ -1,0 +1,98 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.app.core.instances')
+    .factory('horizon.app.core.instances.actions.generic-simple.service', factory);
+
+  factory.$inject = [
+    '$q',
+    'horizon.app.core.openstack-service-api.userSession',
+    'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.actions.action-promise.service',
+    'horizon.framework.util.i18n.gettext',
+    'horizon.framework.util.q.extensions',
+    'horizon.framework.widgets.modal-wait-spinner.service',
+    'horizon.app.core.instances.resourceType'
+  ];
+
+  /**
+   * @ngDoc factory
+   * @name horizon.app.core.instances.actions.delete-instance.service
+   *
+   * @Description
+   * Brings up the delete instance confirmation modal dialog.
+
+   * On submit, delete given instances.
+   * On cancel, do nothing.
+   */
+  function factory(
+    $q,
+    userSessionService,
+    policy,
+    actionPromiseService,
+    gettext,
+    $qExtensions,
+    waitSpinner,
+    instanceResourceType
+  ) {
+
+
+    return function(conf) {
+      var policyPromise;
+      var service = {
+        initScope: initScope,
+        allowed: allowed,
+        perform: perform
+      };
+      var config = conf;
+      return service;
+
+      function initScope() {
+        policyPromise = policy.ifAllowed({rules: config.rules});
+      }
+
+      function perform(item) {
+        waitSpinner.showModalSpinner(gettext('Please Wait'));
+        return config.execute(item).then(onSuccess, onFailure);
+
+        function onSuccess() {
+          waitSpinner.hideModalSpinner();
+          return actionPromiseService.getResolved()
+            .updated(instanceResourceType, item.id)
+            .result;
+        }
+
+        function onFailure() {
+          waitSpinner.hideModalSpinner();
+        }
+      }
+
+      function allowed(instance) {
+        return $q.all([
+          policyPromise,
+          userSessionService.isCurrentProject(instance.owner),
+          properState()
+        ]);
+
+        function properState() {
+          return $qExtensions.booleanAsPromise(config.validState(instance));
+        }
+      }
+    }
+  }
+})();

--- a/openstack_dashboard/static/app/core/instances/actions/hard-reboot.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/hard-reboot.service.js
@@ -1,0 +1,113 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.app.core.instances')
+    .factory('horizon.app.core.instances.actions.hard-reboot.service', factory);
+
+  factory.$inject = [
+    '$q',
+    'horizon.app.core.openstack-service-api.nova',
+    'horizon.app.core.openstack-service-api.userSession',
+    'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.i18n.gettext',
+    'horizon.framework.util.q.extensions',
+    'horizon.framework.widgets.modal-wait-spinner.service',
+    'horizon.app.core.instances.resourceType'
+  ];
+
+  /**
+   * @ngDoc factory
+   * @name horizon.app.core.instances.actions.delete-instance.service
+   *
+   * @Description
+   * Brings up the delete instance confirmation modal dialog.
+
+   * On submit, delete given instances.
+   * On cancel, do nothing.
+   */
+  function factory(
+    $q,
+    nova,
+    userSessionService,
+    policy,
+    gettext,
+    $qExtensions,
+    waitSpinner,
+    instanceResourceType
+  ) {
+    var scope, policyPromise;
+
+    var service = {
+      initScope: initScope,
+      allowed: allowed,
+      perform: perform
+    };
+
+    return service;
+
+    //////////////
+
+    function initScope(newScope) {
+      scope = newScope;
+      policyPromise = policy.ifAllowed({rules: [['instance', 'reboot_instance']]});
+    }
+
+    function perform(item) {
+      waitSpinner.showModalSpinner(gettext('Please Wait'));
+      return nova.hardRebootServer(item.id).then(onSuccess, onFailure);
+
+      function onSuccess() {
+      waitSpinner.hideModalSpinner();
+        return {
+          updated: [{type: instanceResourceType, id: item.id}],
+          deleted: [],
+          created: [],
+          deleted: []
+        };
+      }
+    }
+
+    function allowed(instance) {
+      // only row actions pass in instance
+      // otherwise, assume it is a batch action
+      if (instance) {
+        return $q.all([
+          notProtected(instance),
+          policyPromise,
+          userSessionService.isCurrentProject(instance.owner),
+          properState(instance)
+        ]);
+      }
+      else {
+        return policy.ifAllowed({ rules: [['instance', 'hardReboot_instance']] });
+      }
+    }
+
+    function onFailure() {
+      waitSpinner.hideModalSpinner();
+    }
+
+    function properState(instance) {
+      return $qExtensions.booleanAsPromise(instance.status === 'ACTIVE');
+    }
+
+    function notProtected(instance) {
+      return $qExtensions.booleanAsPromise(!instance.protected);
+    }
+  }
+})();

--- a/openstack_dashboard/static/app/core/instances/actions/hard-reboot.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/hard-reboot.service.js
@@ -18,12 +18,13 @@
   'use strict';
 
   angular
-    .module('horizon.app.core.instances')
+    .module('horizon.app.core.instances.actions')
     .factory('horizon.app.core.instances.actions.hard-reboot.service', factory);
 
   factory.$inject = [
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.instances.actions.generic-simple.service'
+    'horizon.app.core.instances.actions.generic-simple.service',
+    'horizon.app.core.instances.actions.instance-status.service'
   ];
 
   /**
@@ -33,7 +34,7 @@
    * @Description
    * Hard-reboots the instance
    */
-  function factory(nova, simpleService) {
+  function factory(nova, simpleService, statusService) {
 
     var config = {
       rules: [],
@@ -48,9 +49,8 @@
     }
 
     function validState(instance) {
-      return !instance.protected &&
-        (instance.status === 'ACTIVE' || instance.status === 'SHUTOFF') &&
-        instance['OS-EXT-STS:task_state'] !== 'DELETING';
+      return statusService.anyStatus(instance, ['ACTIVE', 'SHUTOFF']) &&
+        !statusService.isDeleting(instance);
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/hard-reboot.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/hard-reboot.service.js
@@ -20,94 +20,33 @@
     .factory('horizon.app.core.instances.actions.hard-reboot.service', factory);
 
   factory.$inject = [
-    '$q',
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.openstack-service-api.userSession',
-    'horizon.app.core.openstack-service-api.policy',
-    'horizon.framework.util.i18n.gettext',
-    'horizon.framework.util.q.extensions',
-    'horizon.framework.widgets.modal-wait-spinner.service',
-    'horizon.app.core.instances.resourceType'
+    'horizon.app.core.instances.actions.generic-simple.service'
   ];
 
   /**
    * @ngDoc factory
-   * @name horizon.app.core.instances.actions.delete-instance.service
+   * @name horizon.app.core.instances.actions.hard-reboot.service
    *
    * @Description
-   * Brings up the delete instance confirmation modal dialog.
-
-   * On submit, delete given instances.
-   * On cancel, do nothing.
+   * Hard-reboots the instance
    */
-  function factory(
-    $q,
-    nova,
-    userSessionService,
-    policy,
-    gettext,
-    $qExtensions,
-    waitSpinner,
-    instanceResourceType
-  ) {
-    var scope, policyPromise;
+  function factory(nova, simpleService) {
 
-    var service = {
-      initScope: initScope,
-      allowed: allowed,
-      perform: perform
-    };
-
-    return service;
-
-    //////////////
-
-    function initScope(newScope) {
-      scope = newScope;
-      policyPromise = policy.ifAllowed({rules: [['instance', 'reboot_instance']]});
+    var config = {
+      rules: [['instance', 'reboot_instance']],
+      execute: execute,
+      validState: validState
     }
 
-    function perform(item) {
-      waitSpinner.showModalSpinner(gettext('Please Wait'));
-      return nova.hardRebootServer(item.id).then(onSuccess, onFailure);
+    return simpleService(config);
 
-      function onSuccess() {
-      waitSpinner.hideModalSpinner();
-        return {
-          updated: [{type: instanceResourceType, id: item.id}],
-          deleted: [],
-          created: [],
-          deleted: []
-        };
-      }
+    function execute(instance) {
+      return nova.hardRebootServer(instance.id);
     }
 
-    function allowed(instance) {
-      // only row actions pass in instance
-      // otherwise, assume it is a batch action
-      if (instance) {
-        return $q.all([
-          notProtected(instance),
-          policyPromise,
-          userSessionService.isCurrentProject(instance.owner),
-          properState(instance)
-        ]);
-      }
-      else {
-        return policy.ifAllowed({ rules: [['instance', 'hardReboot_instance']] });
-      }
-    }
-
-    function onFailure() {
-      waitSpinner.hideModalSpinner();
-    }
-
-    function properState(instance) {
-      return $qExtensions.booleanAsPromise(instance.status === 'ACTIVE');
-    }
-
-    function notProtected(instance) {
-      return $qExtensions.booleanAsPromise(!instance.protected);
+    function validState(instance) {
+      return !instance.protected && instance.status === 'ACTIVE';
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/hard-reboot.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/hard-reboot.service.js
@@ -1,4 +1,6 @@
 /**
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use self file except in compliance with the License. You may obtain
  * a copy of the License at

--- a/openstack_dashboard/static/app/core/instances/actions/hard-reboot.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/hard-reboot.service.js
@@ -34,10 +34,10 @@
   function factory(nova, simpleService) {
 
     var config = {
-      rules: [['instance', 'reboot_instance']],
+      rules: [],
       execute: execute,
       validState: validState
-    }
+    };
 
     return simpleService(config);
 
@@ -46,7 +46,9 @@
     }
 
     function validState(instance) {
-      return !instance.protected && instance.status === 'ACTIVE';
+      return !instance.protected &&
+        (instance.status === 'ACTIVE' || instance.status === 'SHUTOFF') &&
+        instance['OS-EXT-STS:task_state'] !== 'DELETING';
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/instance-status.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/instance-status.service.js
@@ -1,0 +1,61 @@
+/**
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.app.core.instances.actions')
+    .factory('horizon.app.core.instances.actions.instance-status.service', factory);
+
+
+  /**
+   * @ngDoc factory
+   * @name horizon.app.core.instances.actions.instance-status.service
+   *
+   * @Description
+   * Provides useful status-evaluation features.
+   */
+  function factory(
+  ) {
+
+    return {
+      isDeleting: isDeleting,
+      anyStatus: anyStatus,
+      anyPowerState: anyPowerState
+    };
+
+    function anyStatus(instance, validStatuses) {
+      return valueInList(instance.status, validStatuses);
+    }
+
+    function anyPowerState(instance, validStatuses) {
+      return valueInList(instance['OS-EXT-STS:power_state'], validStatuses);
+    }
+
+    function isDeleting(instance) {
+      return upperCase(instance['OS-EXT-STS:task_state']) === 'DELETING';
+    }
+
+    function valueInList(value, list) {
+      return list.indexOf(upperCase(value)) > -1;
+    }
+
+    function upperCase(val) {
+      return String(val).toUpperCase();
+    }
+  }
+})();

--- a/openstack_dashboard/static/app/core/instances/actions/instance-status.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/instance-status.service.js
@@ -43,7 +43,19 @@
     }
 
     function anyPowerState(instance, validStatuses) {
-      return valueInList(instance['OS-EXT-STS:power_state'], validStatuses);
+      var powerStates = {
+        0: "NO STATE",
+        1: "RUNNING",
+        2: "BLOCKED",
+        3: "PAUSED",
+        4: "SHUTDOWN",
+        5: "SHUTOFF",
+        6: "CRASHED",
+        7: "SUSPENDED",
+        8: "FAILED",
+        9: "BUILDING"
+      };
+      return valueInList(powerStates[instance['OS-EXT-STS:power_state']], validStatuses);
     }
 
     function isDeleting(instance) {

--- a/openstack_dashboard/static/app/core/instances/actions/pause.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/pause.service.js
@@ -23,7 +23,8 @@
 
   factory.$inject = [
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.instances.actions.generic-simple.service'
+    'horizon.app.core.instances.actions.generic-simple.service',
+    'horizon.app.core.instances.actions.instance-status.service'
   ];
 
   /**
@@ -33,7 +34,7 @@
    * @Description
    * Pauses the instance
    */
-  function factory(nova, simpleService) {
+  function factory(nova, simpleService, statusService) {
 
     var config = {
       rules: [['compute', 'compute_extension:admin_actions:pause']],
@@ -48,8 +49,9 @@
     }
 
     function validState(instance) {
-      return !instance.protected && instance.status === 'ACTIVE' &&
-        instance['OS-EXT-STS:task_state'] !== 'DELETING';
+      // TODO: Original Python code describes extension-supported: AdminActions
+      return statusService.anyStatus(instance, ['ACTIVE']) &&
+        !statusService.isDeleting(instance);
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/pause.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/pause.service.js
@@ -34,10 +34,10 @@
   function factory(nova, simpleService) {
 
     var config = {
-      rules: [['instance', 'pause_instance']],
+      rules: [['compute', 'compute_extension:admin_actions:pause']],
       execute: execute,
       validState: validState
-    }
+    };
 
     return simpleService(config);
 
@@ -46,7 +46,8 @@
     }
 
     function validState(instance) {
-      return !instance.protected && instance.status === 'ACTIVE';
+      return !instance.protected && instance.status === 'ACTIVE' &&
+        instance['OS-EXT-STS:task_state'] !== 'DELETING';
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/pause.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/pause.service.js
@@ -1,0 +1,113 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.app.core.instances')
+    .factory('horizon.app.core.instances.actions.pause.service', factory);
+
+  factory.$inject = [
+    '$q',
+    'horizon.app.core.openstack-service-api.nova',
+    'horizon.app.core.openstack-service-api.userSession',
+    'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.i18n.gettext',
+    'horizon.framework.util.q.extensions',
+    'horizon.framework.widgets.modal-wait-spinner.service',
+    'horizon.app.core.instances.resourceType'
+  ];
+
+  /**
+   * @ngDoc factory
+   * @name horizon.app.core.instances.actions.delete-instance.service
+   *
+   * @Description
+   * Brings up the delete instance confirmation modal dialog.
+
+   * On submit, delete given instances.
+   * On cancel, do nothing.
+   */
+  function factory(
+    $q,
+    nova,
+    userSessionService,
+    policy,
+    gettext,
+    $qExtensions,
+    waitSpinner,
+    instanceResourceType
+  ) {
+    var scope, policyPromise;
+
+    var service = {
+      initScope: initScope,
+      allowed: allowed,
+      perform: perform
+    };
+
+    return service;
+
+    //////////////
+
+    function initScope(newScope) {
+      scope = newScope;
+      policyPromise = policy.ifAllowed({rules: [['instance', 'pause_instance']]});
+    }
+
+    function perform(item) {
+      waitSpinner.showModalSpinner(gettext('Please Wait'));
+      return nova.pauseServer(item.id).then(onSuccess, onFailure);
+
+      function onSuccess() {
+      waitSpinner.hideModalSpinner();
+        return {
+          updated: [{type: instanceResourceType, id: item.id}],
+          deleted: [],
+          created: [],
+          deleted: []
+        };
+      }
+    }
+
+    function allowed(instance) {
+      // only row actions pass in instance
+      // otherwise, assume it is a batch action
+      if (instance) {
+        return $q.all([
+          notProtected(instance),
+          policyPromise,
+          userSessionService.isCurrentProject(instance.owner),
+          properState(instance)
+        ]);
+      }
+      else {
+        return policy.ifAllowed({ rules: [['instance', 'pause_instance']] });
+      }
+    }
+
+    function onFailure() {
+      waitSpinner.hideModalSpinner();
+    }
+
+    function properState(instance) {
+      return $qExtensions.booleanAsPromise(instance.status === 'ACTIVE' || instance.status === 'ERROR');
+    }
+
+    function notProtected(instance) {
+      return $qExtensions.booleanAsPromise(!instance.protected);
+    }
+  }
+})();

--- a/openstack_dashboard/static/app/core/instances/actions/pause.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/pause.service.js
@@ -1,4 +1,6 @@
 /**
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use self file except in compliance with the License. You may obtain
  * a copy of the License at

--- a/openstack_dashboard/static/app/core/instances/actions/resume.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/resume.service.js
@@ -1,0 +1,113 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.app.core.instances')
+    .factory('horizon.app.core.instances.actions.resume.service', factory);
+
+  factory.$inject = [
+    '$q',
+    'horizon.app.core.openstack-service-api.nova',
+    'horizon.app.core.openstack-service-api.userSession',
+    'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.i18n.gettext',
+    'horizon.framework.util.q.extensions',
+    'horizon.framework.widgets.modal-wait-spinner.service',
+    'horizon.app.core.instances.resourceType'
+  ];
+
+  /**
+   * @ngDoc factory
+   * @name horizon.app.core.instances.actions.delete-instance.service
+   *
+   * @Description
+   * Brings up the delete instance confirmation modal dialog.
+
+   * On submit, delete given instances.
+   * On cancel, do nothing.
+   */
+  function factory(
+    $q,
+    nova,
+    userSessionService,
+    policy,
+    gettext,
+    $qExtensions,
+    waitSpinner,
+    instanceResourceType
+  ) {
+    var scope, policyPromise;
+
+    var service = {
+      initScope: initScope,
+      allowed: allowed,
+      perform: perform
+    };
+
+    return service;
+
+    //////////////
+
+    function initScope(newScope) {
+      scope = newScope;
+      policyPromise = policy.ifAllowed({rules: [['instance', 'resume_instance']]});
+    }
+
+    function perform(item) {
+      waitSpinner.showModalSpinner(gettext('Please Wait'));
+      return nova.resumeServer(item.id).then(onSuccess, onFailure);
+
+      function onSuccess() {
+      waitSpinner.hideModalSpinner();
+        return {
+          updated: [{type: instanceResourceType, id: item.id}],
+          deleted: [],
+          created: [],
+          deleted: []
+        };
+      }
+    }
+
+    function allowed(instance) {
+      // only row actions pass in instance
+      // otherwise, assume it is a batch action
+      if (instance) {
+        return $q.all([
+          notProtected(instance),
+          policyPromise,
+          userSessionService.isCurrentProject(instance.owner),
+          properState(instance)
+        ]);
+      }
+      else {
+        return policy.ifAllowed({ rules: [['instance', 'resume_instance']] });
+      }
+    }
+
+    function onFailure() {
+      waitSpinner.hideModalSpinner();
+    }
+
+    function properState(instance) {
+      return $qExtensions.booleanAsPromise(instance.status === 'SUSPENDED');
+    }
+
+    function notProtected(instance) {
+      return $qExtensions.booleanAsPromise(!instance.protected);
+    }
+  }
+})();

--- a/openstack_dashboard/static/app/core/instances/actions/resume.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/resume.service.js
@@ -34,10 +34,10 @@
   function factory(nova, simpleService) {
 
     var config = {
-      rules: [['instance', 'resume_instance']],
+      rules: [['compute', 'compute_extension:admin_actions:resume']],
       execute: execute,
       validState: validState
-    }
+    };
 
     return simpleService(config);
 
@@ -46,7 +46,8 @@
     }
 
     function validState(instance) {
-      return !instance.protected && instance.status === 'SUSPENDED';
+      return !instance.protected && instance.status === 'SUSPENDED' &&
+        instance['OS-EXT-STS:task_state'] !== 'DELETING';
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/resume.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/resume.service.js
@@ -23,7 +23,8 @@
 
   factory.$inject = [
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.instances.actions.generic-simple.service'
+    'horizon.app.core.instances.actions.generic-simple.service',
+    'horizon.app.core.instances.actions.instance-status.service'
   ];
 
   /**
@@ -33,7 +34,7 @@
    * @Description
    * Resumes the instance
    */
-  function factory(nova, simpleService) {
+  function factory(nova, simpleService, statusService) {
 
     var config = {
       rules: [['compute', 'compute_extension:admin_actions:resume']],
@@ -48,8 +49,8 @@
     }
 
     function validState(instance) {
-      return !instance.protected && instance.status === 'SUSPENDED' &&
-        instance['OS-EXT-STS:task_state'] !== 'DELETING';
+      return statusService.anyStatus(instance, ['SUSPENDED']) &&
+        !statusService.isDeleting(instance);
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/resume.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/resume.service.js
@@ -1,4 +1,6 @@
 /**
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use self file except in compliance with the License. You may obtain
  * a copy of the License at

--- a/openstack_dashboard/static/app/core/instances/actions/soft-reboot.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/soft-reboot.service.js
@@ -1,0 +1,113 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.app.core.instances')
+    .factory('horizon.app.core.instances.actions.soft-reboot.service', factory);
+
+  factory.$inject = [
+    '$q',
+    'horizon.app.core.openstack-service-api.nova',
+    'horizon.app.core.openstack-service-api.userSession',
+    'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.i18n.gettext',
+    'horizon.framework.util.q.extensions',
+    'horizon.framework.widgets.modal-wait-spinner.service',
+    'horizon.app.core.instances.resourceType'
+  ];
+
+  /**
+   * @ngDoc factory
+   * @name horizon.app.core.instances.actions.delete-instance.service
+   *
+   * @Description
+   * Brings up the delete instance confirmation modal dialog.
+
+   * On submit, delete given instances.
+   * On cancel, do nothing.
+   */
+  function factory(
+    $q,
+    nova,
+    userSessionService,
+    policy,
+    gettext,
+    $qExtensions,
+    waitSpinner,
+    instanceResourceType
+  ) {
+    var scope, policyPromise;
+
+    var service = {
+      initScope: initScope,
+      allowed: allowed,
+      perform: perform
+    };
+
+    return service;
+
+    //////////////
+
+    function initScope(newScope) {
+      scope = newScope;
+      policyPromise = policy.ifAllowed({rules: [['instance', 'reboot_instance']]});
+    }
+
+    function perform(item) {
+      waitSpinner.showModalSpinner(gettext('Please Wait'));
+      return nova.softRebootServer(item.id).then(onSuccess, onFailure);
+
+      function onSuccess() {
+      waitSpinner.hideModalSpinner();
+        return {
+          updated: [{type: instanceResourceType, id: item.id}],
+          deleted: [],
+          created: [],
+          deleted: []
+        };
+      }
+    }
+
+    function allowed(instance) {
+      // only row actions pass in instance
+      // otherwise, assume it is a batch action
+      if (instance) {
+        return $q.all([
+          notProtected(instance),
+          policyPromise,
+          userSessionService.isCurrentProject(instance.owner),
+          properState(instance)
+        ]);
+      }
+      else {
+        return policy.ifAllowed({ rules: [['instance', 'reboot_instance']] });
+      }
+    }
+
+    function onFailure() {
+      waitSpinner.hideModalSpinner();
+    }
+
+    function properState(instance) {
+      return $qExtensions.booleanAsPromise(instance.status === 'ACTIVE');
+    }
+
+    function notProtected(instance) {
+      return $qExtensions.booleanAsPromise(!instance.protected);
+    }
+  }
+})();

--- a/openstack_dashboard/static/app/core/instances/actions/soft-reboot.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/soft-reboot.service.js
@@ -20,94 +20,33 @@
     .factory('horizon.app.core.instances.actions.soft-reboot.service', factory);
 
   factory.$inject = [
-    '$q',
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.openstack-service-api.userSession',
-    'horizon.app.core.openstack-service-api.policy',
-    'horizon.framework.util.i18n.gettext',
-    'horizon.framework.util.q.extensions',
-    'horizon.framework.widgets.modal-wait-spinner.service',
-    'horizon.app.core.instances.resourceType'
+    'horizon.app.core.instances.actions.generic-simple.service'
   ];
 
   /**
    * @ngDoc factory
-   * @name horizon.app.core.instances.actions.delete-instance.service
+   * @name horizon.app.core.instances.actions.soft-reboot.service
    *
    * @Description
-   * Brings up the delete instance confirmation modal dialog.
-
-   * On submit, delete given instances.
-   * On cancel, do nothing.
+   * Soft-reboots the instance
    */
-  function factory(
-    $q,
-    nova,
-    userSessionService,
-    policy,
-    gettext,
-    $qExtensions,
-    waitSpinner,
-    instanceResourceType
-  ) {
-    var scope, policyPromise;
+  function factory(nova, simpleService) {
 
-    var service = {
-      initScope: initScope,
-      allowed: allowed,
-      perform: perform
-    };
-
-    return service;
-
-    //////////////
-
-    function initScope(newScope) {
-      scope = newScope;
-      policyPromise = policy.ifAllowed({rules: [['instance', 'reboot_instance']]});
+    var config = {
+      rules: [['instance', 'reboot_instance']],
+      execute: execute,
+      validState: validState
     }
 
-    function perform(item) {
-      waitSpinner.showModalSpinner(gettext('Please Wait'));
-      return nova.softRebootServer(item.id).then(onSuccess, onFailure);
+    return simpleService(config);
 
-      function onSuccess() {
-      waitSpinner.hideModalSpinner();
-        return {
-          updated: [{type: instanceResourceType, id: item.id}],
-          deleted: [],
-          created: [],
-          deleted: []
-        };
-      }
+    function execute(instance) {
+      return nova.softRebootServer(instance.id);
     }
 
-    function allowed(instance) {
-      // only row actions pass in instance
-      // otherwise, assume it is a batch action
-      if (instance) {
-        return $q.all([
-          notProtected(instance),
-          policyPromise,
-          userSessionService.isCurrentProject(instance.owner),
-          properState(instance)
-        ]);
-      }
-      else {
-        return policy.ifAllowed({ rules: [['instance', 'reboot_instance']] });
-      }
-    }
-
-    function onFailure() {
-      waitSpinner.hideModalSpinner();
-    }
-
-    function properState(instance) {
-      return $qExtensions.booleanAsPromise(instance.status === 'ACTIVE');
-    }
-
-    function notProtected(instance) {
-      return $qExtensions.booleanAsPromise(!instance.protected);
+    function validState(instance) {
+      return !instance.protected && instance.status === 'ACTIVE';
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/soft-reboot.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/soft-reboot.service.js
@@ -1,4 +1,6 @@
 /**
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use self file except in compliance with the License. You may obtain
  * a copy of the License at

--- a/openstack_dashboard/static/app/core/instances/actions/soft-reboot.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/soft-reboot.service.js
@@ -34,10 +34,10 @@
   function factory(nova, simpleService) {
 
     var config = {
-      rules: [['instance', 'reboot_instance']],
+      rules: [],
       execute: execute,
       validState: validState
-    }
+    };
 
     return simpleService(config);
 
@@ -46,7 +46,9 @@
     }
 
     function validState(instance) {
-      return !instance.protected && instance.status === 'ACTIVE';
+      return !instance.protected &&
+        (instance.status === 'ACTIVE' || instance.status === 'SHUTOFF') &&
+        instance['OS-EXT-STS:task_state'] !== 'DELETING';
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/soft-reboot.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/soft-reboot.service.js
@@ -23,7 +23,8 @@
 
   factory.$inject = [
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.instances.actions.generic-simple.service'
+    'horizon.app.core.instances.actions.generic-simple.service',
+    'horizon.app.core.instances.actions.instance-status.service'
   ];
 
   /**
@@ -33,7 +34,7 @@
    * @Description
    * Soft-reboots the instance
    */
-  function factory(nova, simpleService) {
+  function factory(nova, simpleService, statusService) {
 
     var config = {
       rules: [],
@@ -48,9 +49,8 @@
     }
 
     function validState(instance) {
-      return !instance.protected &&
-        (instance.status === 'ACTIVE' || instance.status === 'SHUTOFF') &&
-        instance['OS-EXT-STS:task_state'] !== 'DELETING';
+      return statusService.anyStatus(instance, ['ACTIVE', 'SHUTOFF']) &&
+        !statusService.isDeleting(instance);
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/start.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/start.service.js
@@ -24,6 +24,7 @@
     'horizon.app.core.openstack-service-api.nova',
     'horizon.app.core.openstack-service-api.userSession',
     'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.i18n.gettext',
     'horizon.framework.util.q.extensions',
     'horizon.framework.widgets.modal-wait-spinner.service',
     'horizon.app.core.instances.resourceType'
@@ -44,6 +45,7 @@
     nova,
     userSessionService,
     policy,
+    gettext,
     $qExtensions,
     waitSpinner,
     instanceResourceType
@@ -66,7 +68,7 @@
     }
 
     function perform(item) {
-      waitSpinner.showModalSpinner();
+      waitSpinner.showModalSpinner(gettext('Please Wait'));
       return nova.startServer(item.id).then(onSuccess, onFailure);
 
       function onSuccess() {
@@ -100,6 +102,7 @@
       waitSpinner.hideModalSpinner();
     }
     function properState(instance) {
+      console.log('evaluating instance ' + instance.name + ' ' + instance.status);
       return $qExtensions.booleanAsPromise(instance.status === 'SHUTOFF');
     }
 

--- a/openstack_dashboard/static/app/core/instances/actions/start.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/start.service.js
@@ -1,0 +1,146 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.app.core.instances')
+    .factory('horizon.app.core.instances.actions.start.service', factory);
+
+  factory.$inject = [
+    '$q',
+    'horizon.app.core.openstack-service-api.nova',
+    'horizon.app.core.openstack-service-api.userSession',
+    'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.i18n.gettext',
+    'horizon.framework.util.q.extensions',
+    'horizon.framework.widgets.modal.deleteModalService',
+    'horizon.framework.widgets.modal-wait-spinner.service',
+    'horizon.framework.widgets.toast.service',
+    'horizon.app.core.instances.resourceType'
+  ];
+
+  /**
+   * @ngDoc factory
+   * @name horizon.app.core.instances.actions.delete-instance.service
+   *
+   * @Description
+   * Brings up the delete instance confirmation modal dialog.
+
+   * On submit, delete given instances.
+   * On cancel, do nothing.
+   */
+  function factory(
+    $q,
+    nova,
+    userSessionService,
+    policy,
+    gettext,
+    $qExtensions,
+    deleteModal,
+    waitSpinner,
+    toast,
+    instanceResourceType
+  ) {
+    var scope, context, policyPromise;
+    var notAllowedMessage = gettext("You are not allowed to start instances: %s");
+
+    var service = {
+      initScope: initScope,
+      allowed: allowed,
+      perform: perform
+    };
+
+    return service;
+
+    //////////////
+
+    function initScope(newScope) {
+      scope = newScope;
+      context = { };
+      policyPromise = policy.ifAllowed({rules: [['instance', 'start_instance']]});
+    }
+
+    function perform(item) {
+      return nova.startServer(item.id).then(onSuccess);
+
+      function onSuccess() {
+        return {
+          updated: [{type: instanceResourceType, id: item.id}],
+          deleted: [],
+          created: [],
+          deleted: []
+        };
+      }
+    }
+
+
+    function allowed(instance) {
+      // only row actions pass in instance
+      // otherwise, assume it is a batch action
+      if (instance) {
+        return $q.all([
+          notProtected(instance),
+          policyPromise,
+          userSessionService.isCurrentProject(instance.owner),
+          notDeleted(instance)
+          // TODO: only valid states are ACTIVE or ERROR
+        ]);
+      }
+      else {
+        return policy.ifAllowed({ rules: [['instance', 'start_instance']] });
+      }
+    }
+
+    function checkPermission(instance) {
+      return {promise: allowed(instance), context: instance};
+    }
+
+    function createResult(deleteModalResult) {
+      // To make the result of this action generically useful, reformat the return
+      // from the deleteModal into a standard form
+      waitSpinner.hideModalSpinner();
+      return {
+        created: [],
+        updated: [],
+        deleted: deleteModalResult.pass.map( mapModalResult ),
+        failed: deleteModalResult.fail.map( mapModalResult )
+      };
+    }
+
+    function onCancel() {
+      waitSpinner.hideModalSpinner();
+    }
+    function notDeleted(instance) {
+      return $qExtensions.booleanAsPromise(instance.status !== 'deleted');
+    }
+
+    function notProtected(instance) {
+      return $qExtensions.booleanAsPromise(!instance.protected);
+    }
+
+    function getMessage(message, entities) {
+      return interpolate(message, [entities.map(getName).join(", ")]);
+    }
+
+    function getName(result) {
+      return getEntity(result).name;
+    }
+
+    function getEntity(result) {
+      return result.context;
+    }
+  }
+})();

--- a/openstack_dashboard/static/app/core/instances/actions/start.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/start.service.js
@@ -23,7 +23,8 @@
 
   factory.$inject = [
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.instances.actions.generic-simple.service'
+    'horizon.app.core.instances.actions.generic-simple.service',
+    'horizon.app.core.instances.actions.instance-status.service'
   ];
 
   /**
@@ -33,7 +34,7 @@
    * @Description
    * Starts the instance
    */
-  function factory(nova, simpleService) {
+  function factory(nova, simpleService, statusService) {
 
     var config = {
       rules: [['compute', 'compute:start']],
@@ -48,8 +49,7 @@
     }
 
     function validState(instance) {
-      return !instance.protected && (instance.status === 'SHUTDOWN' ||
-        instance.status === 'SHUTOFF' || instance.status === 'CRASHED');
+      return statusService.anyStatus(instance, ['SHUTDOWN', 'SHUTOFF', 'CRASHED']);
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/start.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/start.service.js
@@ -1,4 +1,6 @@
 /**
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use self file except in compliance with the License. You may obtain
  * a copy of the License at

--- a/openstack_dashboard/static/app/core/instances/actions/start.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/start.service.js
@@ -102,7 +102,6 @@
       waitSpinner.hideModalSpinner();
     }
     function properState(instance) {
-      console.log('evaluating instance ' + instance.name + ' ' + instance.status);
       return $qExtensions.booleanAsPromise(instance.status === 'SHUTOFF');
     }
 

--- a/openstack_dashboard/static/app/core/instances/actions/start.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/start.service.js
@@ -34,10 +34,10 @@
   function factory(nova, simpleService) {
 
     var config = {
-      rules: [['instance', 'start_instance']],
+      rules: [['compute', 'compute:start']],
       execute: execute,
       validState: validState
-    }
+    };
 
     return simpleService(config);
 
@@ -46,7 +46,8 @@
     }
 
     function validState(instance) {
-      return !instance.protected && instance.status === 'SHUTOFF';
+      return !instance.protected && (instance.status === 'SHUTDOWN' ||
+        instance.status === 'SHUTOFF' || instance.status === 'CRASHED');
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/stop.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/stop.service.js
@@ -23,7 +23,8 @@
 
   factory.$inject = [
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.instances.actions.generic-simple.service'
+    'horizon.app.core.instances.actions.generic-simple.service',
+    'horizon.app.core.instances.actions.instance-status.service'
   ];
 
   /**
@@ -33,7 +34,7 @@
    * @Description
    * Stops the instance.
    */
-  function factory(nova, simpleService) {
+  function factory(nova, simpleService, statusService) {
 
     var config = {
       rules: [['compute', 'compute:stop']],
@@ -48,10 +49,9 @@
     }
 
     function validState(instance) {
-      return  (instance.status === 'ACTIVE' || instance.status === 'ERROR' ||
-        instance['OS-EXT-STS:power_state'] === 'RUNNING' ||
-        instance['OS-EXT-STS:power_state'] === 'SUSPENDED') &&
-        instance['OS-EXT-STS:task_state'] !== 'DELETING';
+      return (statusService.anyStatus(instance, ['ACTIVE', 'ERROR']) ||
+        statusService.anyPowerState(instance, ['RUNNING', 'SUSPENDED'])) &&
+        !statusService.isDeleting(instance);
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/stop.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/stop.service.js
@@ -1,4 +1,6 @@
 /**
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use self file except in compliance with the License. You may obtain
  * a copy of the License at
@@ -46,8 +48,8 @@
     }
 
     function validState(instance) {
-      return !instance.protected &&
-        (instance['OS-EXT-STS:power_state'] === 'RUNNING' ||
+      return  (instance.status === 'ACTIVE' || instance.status === 'ERROR' ||
+        instance['OS-EXT-STS:power_state'] === 'RUNNING' ||
         instance['OS-EXT-STS:power_state'] === 'SUSPENDED') &&
         instance['OS-EXT-STS:task_state'] !== 'DELETING';
     }

--- a/openstack_dashboard/static/app/core/instances/actions/stop.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/stop.service.js
@@ -34,10 +34,10 @@
   function factory(nova, simpleService) {
 
     var config = {
-      rules: [['instance', 'stop_instance']],
+      rules: [['compute', 'compute:stop']],
       execute: execute,
       validState: validState
-    }
+    };
 
     return simpleService(config);
 
@@ -47,7 +47,9 @@
 
     function validState(instance) {
       return !instance.protected &&
-        (instance.status === 'ACTIVE' || instance.status === 'ERROR');
+        (instance['OS-EXT-STS:power_state'] === 'RUNNING' ||
+        instance['OS-EXT-STS:power_state'] === 'SUSPENDED') &&
+        instance['OS-EXT-STS:task_state'] !== 'DELETING';
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/stop.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/stop.service.js
@@ -20,95 +20,34 @@
     .factory('horizon.app.core.instances.actions.stop.service', factory);
 
   factory.$inject = [
-    '$q',
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.openstack-service-api.userSession',
-    'horizon.app.core.openstack-service-api.policy',
-    'horizon.framework.util.i18n.gettext',
-    'horizon.framework.util.q.extensions',
-    'horizon.framework.widgets.modal-wait-spinner.service',
-    'horizon.app.core.instances.resourceType'
+    'horizon.app.core.instances.actions.generic-simple.service'
   ];
 
   /**
    * @ngDoc factory
-   * @name horizon.app.core.instances.actions.delete-instance.service
+   * @name horizon.app.core.instances.actions.stop.service
    *
    * @Description
-   * Brings up the delete instance confirmation modal dialog.
-
-   * On submit, delete given instances.
-   * On cancel, do nothing.
+   * Stops the instance.
    */
-  function factory(
-    $q,
-    nova,
-    userSessionService,
-    policy,
-    gettext,
-    $qExtensions,
-    waitSpinner,
-    instanceResourceType
-  ) {
-    var scope, policyPromise;
+  function factory(nova, simpleService) {
 
-    var service = {
-      initScope: initScope,
-      allowed: allowed,
-      perform: perform
-    };
-
-    return service;
-
-    //////////////
-
-    function initScope(newScope) {
-      scope = newScope;
-      policyPromise = policy.ifAllowed({rules: [['instance', 'stop_instance']]});
+    var config = {
+      rules: [['instance', 'stop_instance']],
+      execute: execute,
+      validState: validState
     }
 
-    function perform(item) {
-      waitSpinner.showModalSpinner(gettext('Please Wait'));
-      return nova.stopServer(item.id).then(onSuccess, onFailure);
+    return simpleService(config);
 
-      function onSuccess() {
-      waitSpinner.hideModalSpinner();
-        return {
-          updated: [{type: instanceResourceType, id: item.id}],
-          deleted: [],
-          created: [],
-          deleted: []
-        };
-      }
+    function execute(instance) {
+      return nova.stopServer(instance.id);
     }
 
-
-    function allowed(instance) {
-      // only row actions pass in instance
-      // otherwise, assume it is a batch action
-      if (instance) {
-        return $q.all([
-          notProtected(instance),
-          policyPromise,
-          userSessionService.isCurrentProject(instance.owner),
-          properState(instance)
-        ]);
-      }
-      else {
-        return policy.ifAllowed({ rules: [['instance', 'stop_instance']] });
-      }
-    }
-
-    function onFailure() {
-      waitSpinner.hideModalSpinner();
-    }
-
-    function properState(instance) {
-      return $qExtensions.booleanAsPromise(instance.status === 'ACTIVE' || instance.status === 'ERROR');
-    }
-
-    function notProtected(instance) {
-      return $qExtensions.booleanAsPromise(!instance.protected);
+    function validState(instance) {
+      return !instance.protected &&
+        (instance.status === 'ACTIVE' || instance.status === 'ERROR');
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/stop.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/stop.service.js
@@ -49,8 +49,7 @@
     }
 
     function validState(instance) {
-      return (statusService.anyStatus(instance, ['ACTIVE', 'ERROR']) ||
-        statusService.anyPowerState(instance, ['RUNNING', 'SUSPENDED'])) &&
+      return statusService.anyPowerState(instance, ['RUNNING', 'SUSPENDED']) &&
         !statusService.isDeleting(instance);
     }
   }

--- a/openstack_dashboard/static/app/core/instances/actions/stop.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/stop.service.js
@@ -1,0 +1,146 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.app.core.instances')
+    .factory('horizon.app.core.instances.actions.stop.service', factory);
+
+  factory.$inject = [
+    '$q',
+    'horizon.app.core.openstack-service-api.nova',
+    'horizon.app.core.openstack-service-api.userSession',
+    'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.i18n.gettext',
+    'horizon.framework.util.q.extensions',
+    'horizon.framework.widgets.modal.deleteModalService',
+    'horizon.framework.widgets.modal-wait-spinner.service',
+    'horizon.framework.widgets.toast.service',
+    'horizon.app.core.instances.resourceType'
+  ];
+
+  /**
+   * @ngDoc factory
+   * @name horizon.app.core.instances.actions.delete-instance.service
+   *
+   * @Description
+   * Brings up the delete instance confirmation modal dialog.
+
+   * On submit, delete given instances.
+   * On cancel, do nothing.
+   */
+  function factory(
+    $q,
+    nova,
+    userSessionService,
+    policy,
+    gettext,
+    $qExtensions,
+    deleteModal,
+    waitSpinner,
+    toast,
+    instanceResourceType
+  ) {
+    var scope, context, policyPromise;
+    var notAllowedMessage = gettext("You are not allowed to stop instances: %s");
+
+    var service = {
+      initScope: initScope,
+      allowed: allowed,
+      perform: perform
+    };
+
+    return service;
+
+    //////////////
+
+    function initScope(newScope) {
+      scope = newScope;
+      context = { };
+      policyPromise = policy.ifAllowed({rules: [['instance', 'stop_instance']]});
+    }
+
+    function perform(item) {
+      return nova.stopServer(item.id).then(onSuccess);
+
+      function onSuccess() {
+        return {
+          updated: [{type: instanceResourceType, id: item.id}],
+          deleted: [],
+          created: [],
+          deleted: []
+        };
+      }
+    }
+
+
+    function allowed(instance) {
+      // only row actions pass in instance
+      // otherwise, assume it is a batch action
+      if (instance) {
+        return $q.all([
+          notProtected(instance),
+          policyPromise,
+          userSessionService.isCurrentProject(instance.owner),
+          notDeleted(instance)
+          // TODO: only valid states are ACTIVE or ERROR
+        ]);
+      }
+      else {
+        return policy.ifAllowed({ rules: [['instance', 'stop_instance']] });
+      }
+    }
+
+    function checkPermission(instance) {
+      return {promise: allowed(instance), context: instance};
+    }
+
+    function createResult(deleteModalResult) {
+      // To make the result of this action generically useful, reformat the return
+      // from the deleteModal into a standard form
+      waitSpinner.hideModalSpinner();
+      return {
+        created: [],
+        updated: [],
+        deleted: deleteModalResult.pass.map( mapModalResult ),
+        failed: deleteModalResult.fail.map( mapModalResult )
+      };
+    }
+
+    function onCancel() {
+      waitSpinner.hideModalSpinner();
+    }
+    function notDeleted(instance) {
+      return $qExtensions.booleanAsPromise(instance.status !== 'deleted');
+    }
+
+    function notProtected(instance) {
+      return $qExtensions.booleanAsPromise(!instance.protected);
+    }
+
+    function getMessage(message, entities) {
+      return interpolate(message, [entities.map(getName).join(", ")]);
+    }
+
+    function getName(result) {
+      return getEntity(result).name;
+    }
+
+    function getEntity(result) {
+      return result.context;
+    }
+  }
+})();

--- a/openstack_dashboard/static/app/core/instances/actions/stop.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/stop.service.js
@@ -24,6 +24,7 @@
     'horizon.app.core.openstack-service-api.nova',
     'horizon.app.core.openstack-service-api.userSession',
     'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.i18n.gettext',
     'horizon.framework.util.q.extensions',
     'horizon.framework.widgets.modal-wait-spinner.service',
     'horizon.app.core.instances.resourceType'
@@ -44,6 +45,7 @@
     nova,
     userSessionService,
     policy,
+    gettext,
     $qExtensions,
     waitSpinner,
     instanceResourceType
@@ -66,7 +68,7 @@
     }
 
     function perform(item) {
-      waitSpinner.showModalSpinner();
+      waitSpinner.showModalSpinner(gettext('Please Wait'));
       return nova.stopServer(item.id).then(onSuccess, onFailure);
 
       function onSuccess() {

--- a/openstack_dashboard/static/app/core/instances/actions/suspend.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/suspend.service.js
@@ -1,0 +1,113 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.app.core.instances')
+    .factory('horizon.app.core.instances.actions.suspend.service', factory);
+
+  factory.$inject = [
+    '$q',
+    'horizon.app.core.openstack-service-api.nova',
+    'horizon.app.core.openstack-service-api.userSession',
+    'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.i18n.gettext',
+    'horizon.framework.util.q.extensions',
+    'horizon.framework.widgets.modal-wait-spinner.service',
+    'horizon.app.core.instances.resourceType'
+  ];
+
+  /**
+   * @ngDoc factory
+   * @name horizon.app.core.instances.actions.delete-instance.service
+   *
+   * @Description
+   * Brings up the delete instance confirmation modal dialog.
+
+   * On submit, delete given instances.
+   * On cancel, do nothing.
+   */
+  function factory(
+    $q,
+    nova,
+    userSessionService,
+    policy,
+    gettext,
+    $qExtensions,
+    waitSpinner,
+    instanceResourceType
+  ) {
+    var scope, policyPromise;
+
+    var service = {
+      initScope: initScope,
+      allowed: allowed,
+      perform: perform
+    };
+
+    return service;
+
+    //////////////
+
+    function initScope(newScope) {
+      scope = newScope;
+      policyPromise = policy.ifAllowed({rules: [['instance', 'suspend_instance']]});
+    }
+
+    function perform(item) {
+      waitSpinner.showModalSpinner(gettext('Please Wait'));
+      return nova.suspendServer(item.id).then(onSuccess, onFailure);
+
+      function onSuccess() {
+      waitSpinner.hideModalSpinner();
+        return {
+          updated: [{type: instanceResourceType, id: item.id}],
+          deleted: [],
+          created: [],
+          deleted: []
+        };
+      }
+    }
+
+    function allowed(instance) {
+      // only row actions pass in instance
+      // otherwise, assume it is a batch action
+      if (instance) {
+        return $q.all([
+          notProtected(instance),
+          policyPromise,
+          userSessionService.isCurrentProject(instance.owner),
+          properState(instance)
+        ]);
+      }
+      else {
+        return policy.ifAllowed({ rules: [['instance', 'suspend_instance']] });
+      }
+    }
+
+    function onFailure() {
+      waitSpinner.hideModalSpinner();
+    }
+
+    function properState(instance) {
+      return $qExtensions.booleanAsPromise(instance.status === 'ACTIVE');
+    }
+
+    function notProtected(instance) {
+      return $qExtensions.booleanAsPromise(!instance.protected);
+    }
+  }
+})();

--- a/openstack_dashboard/static/app/core/instances/actions/suspend.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/suspend.service.js
@@ -23,7 +23,8 @@
 
   factory.$inject = [
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.instances.actions.generic-simple.service'
+    'horizon.app.core.instances.actions.generic-simple.service',
+    'horizon.app.core.instances.actions.instance-status.service'
   ];
 
   /**
@@ -33,7 +34,7 @@
    * @Description
    * Suspends the instance
    */
-  function factory(nova, simpleService) {
+  function factory(nova, simpleService, statusService) {
 
     var config = {
       rules: [['compute', 'compute_extension:admin_actions:suspend']],
@@ -48,8 +49,8 @@
     }
 
     function validState(instance) {
-      return !instance.protected && instance.status === 'ACTIVE' &&
-        instance['OS-EXT-STS:task_state'] !== 'DELETING';
+      return statusService.anyStatus(instance, ['ACTIVE']) &&
+        !statusService.isDeleting(instance);
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/suspend.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/suspend.service.js
@@ -34,10 +34,10 @@
   function factory(nova, simpleService) {
 
     var config = {
-      rules: [['instance', 'suspend_instance']],
+      rules: [['compute', 'compute_extension:admin_actions:suspend']],
       execute: execute,
       validState: validState
-    }
+    };
 
     return simpleService(config);
 
@@ -46,7 +46,8 @@
     }
 
     function validState(instance) {
-      return !instance.protected && instance.status === 'ACTIVE';
+      return !instance.protected && instance.status === 'ACTIVE' &&
+        instance['OS-EXT-STS:task_state'] !== 'DELETING';
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/suspend.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/suspend.service.js
@@ -1,4 +1,6 @@
 /**
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use self file except in compliance with the License. You may obtain
  * a copy of the License at

--- a/openstack_dashboard/static/app/core/instances/actions/suspend.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/suspend.service.js
@@ -20,94 +20,33 @@
     .factory('horizon.app.core.instances.actions.suspend.service', factory);
 
   factory.$inject = [
-    '$q',
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.openstack-service-api.userSession',
-    'horizon.app.core.openstack-service-api.policy',
-    'horizon.framework.util.i18n.gettext',
-    'horizon.framework.util.q.extensions',
-    'horizon.framework.widgets.modal-wait-spinner.service',
-    'horizon.app.core.instances.resourceType'
+    'horizon.app.core.instances.actions.generic-simple.service'
   ];
 
   /**
    * @ngDoc factory
-   * @name horizon.app.core.instances.actions.delete-instance.service
+   * @name horizon.app.core.instances.actions.suspend.service
    *
    * @Description
-   * Brings up the delete instance confirmation modal dialog.
-
-   * On submit, delete given instances.
-   * On cancel, do nothing.
+   * Suspends the instance
    */
-  function factory(
-    $q,
-    nova,
-    userSessionService,
-    policy,
-    gettext,
-    $qExtensions,
-    waitSpinner,
-    instanceResourceType
-  ) {
-    var scope, policyPromise;
+  function factory(nova, simpleService) {
 
-    var service = {
-      initScope: initScope,
-      allowed: allowed,
-      perform: perform
-    };
-
-    return service;
-
-    //////////////
-
-    function initScope(newScope) {
-      scope = newScope;
-      policyPromise = policy.ifAllowed({rules: [['instance', 'suspend_instance']]});
+    var config = {
+      rules: [['instance', 'suspend_instance']],
+      execute: execute,
+      validState: validState
     }
 
-    function perform(item) {
-      waitSpinner.showModalSpinner(gettext('Please Wait'));
-      return nova.suspendServer(item.id).then(onSuccess, onFailure);
+    return simpleService(config);
 
-      function onSuccess() {
-      waitSpinner.hideModalSpinner();
-        return {
-          updated: [{type: instanceResourceType, id: item.id}],
-          deleted: [],
-          created: [],
-          deleted: []
-        };
-      }
+    function execute(instance) {
+      return nova.suspendServer(instance.id);
     }
 
-    function allowed(instance) {
-      // only row actions pass in instance
-      // otherwise, assume it is a batch action
-      if (instance) {
-        return $q.all([
-          notProtected(instance),
-          policyPromise,
-          userSessionService.isCurrentProject(instance.owner),
-          properState(instance)
-        ]);
-      }
-      else {
-        return policy.ifAllowed({ rules: [['instance', 'suspend_instance']] });
-      }
-    }
-
-    function onFailure() {
-      waitSpinner.hideModalSpinner();
-    }
-
-    function properState(instance) {
-      return $qExtensions.booleanAsPromise(instance.status === 'ACTIVE');
-    }
-
-    function notProtected(instance) {
-      return $qExtensions.booleanAsPromise(!instance.protected);
+    function validState(instance) {
+      return !instance.protected && instance.status === 'ACTIVE';
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
@@ -23,7 +23,8 @@
 
   factory.$inject = [
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.instances.actions.generic-simple.service'
+    'horizon.app.core.instances.actions.generic-simple.service',
+    'horizon.app.core.instances.actions.instance-status.service'
   ];
 
   /**
@@ -33,7 +34,7 @@
    * @Description
    * Un-Pauses the instance
    */
-  function factory(nova, simpleService) {
+  function factory(nova, simpleService, statusService) {
 
     var config = {
       rules: [['compute', 'compute_extension:admin_actions:unpause']],
@@ -48,8 +49,8 @@
     }
 
     function validState(instance) {
-      return !instance.protected && instance.status === 'PAUSED' &&
-        instance['OS-EXT-STS:task_state'] !== 'DELETING';
+      return statusService.anyStatus(instance, ['PAUSED']) &&
+        !statusService.isDeleting(instance);
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
@@ -24,6 +24,7 @@
     'horizon.app.core.openstack-service-api.nova',
     'horizon.app.core.openstack-service-api.userSession',
     'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.actions.action-promise.service',
     'horizon.framework.util.i18n.gettext',
     'horizon.framework.util.q.extensions',
     'horizon.framework.widgets.modal-wait-spinner.service',
@@ -42,12 +43,13 @@
     nova,
     userSessionService,
     policy,
+    actionPromiseService,
     gettext,
     $qExtensions,
     waitSpinner,
     instanceResourceType
   ) {
-    var scope, policyPromise;
+    var policyPromise;
 
     var service = {
       initScope: initScope,
@@ -59,8 +61,7 @@
 
     //////////////
 
-    function initScope(newScope) {
-      scope = newScope;
+    function initScope() {
       policyPromise = policy.ifAllowed({rules: [['instance', 'unpause_instance']]});
     }
 
@@ -69,42 +70,28 @@
       return nova.unpauseServer(item.id).then(onSuccess, onFailure);
 
       function onSuccess() {
-      waitSpinner.hideModalSpinner();
-        return {
-          updated: [{type: instanceResourceType, id: item.id}],
-          deleted: [],
-          created: [],
-          deleted: []
-        };
+        waitSpinner.hideModalSpinner();
+        return actionPromiseService.getResolved()
+          .updated(instanceResourceType, item.id)
+          .result;
+      }
+
+      function onFailure() {
+        waitSpinner.hideModalSpinner();
       }
     }
 
     function allowed(instance) {
-      // only row actions pass in instance
-      // otherwise, assume it is a batch action
-      if (instance) {
-        return $q.all([
-          notProtected(instance),
-          policyPromise,
-          userSessionService.isCurrentProject(instance.owner),
-          properState(instance)
-        ]);
+      return $q.all([
+        policyPromise,
+        userSessionService.isCurrentProject(instance.owner),
+        properState(instance)
+      ]);
+
+      function properState(instance) {
+        var proper = !instance.protected && instance.status === 'PAUSED';
+        return $qExtensions.booleanAsPromise(proper);
       }
-      else {
-        return policy.ifAllowed({ rules: [['instance', 'unpause_instance']] });
-      }
-    }
-
-    function onFailure() {
-      waitSpinner.hideModalSpinner();
-    }
-
-    function properState(instance) {
-      return $qExtensions.booleanAsPromise(instance.status === 'PAUSED');
-    }
-
-    function notProtected(instance) {
-      return $qExtensions.booleanAsPromise(!instance.protected);
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
@@ -20,78 +20,33 @@
     .factory('horizon.app.core.instances.actions.unpause.service', factory);
 
   factory.$inject = [
-    '$q',
     'horizon.app.core.openstack-service-api.nova',
-    'horizon.app.core.openstack-service-api.userSession',
-    'horizon.app.core.openstack-service-api.policy',
-    'horizon.framework.util.actions.action-promise.service',
-    'horizon.framework.util.i18n.gettext',
-    'horizon.framework.util.q.extensions',
-    'horizon.framework.widgets.modal-wait-spinner.service',
-    'horizon.app.core.instances.resourceType'
+    'horizon.app.core.instances.actions.generic-simple.service'
   ];
 
   /**
    * @ngDoc factory
-   * @name horizon.app.core.instances.actions.delete-instance.service
+   * @name horizon.app.core.instances.actions.unpause.service
    *
    * @Description
-   * Pauses the given server.
+   * Un-Pauses the instance
    */
-  function factory(
-    $q,
-    nova,
-    userSessionService,
-    policy,
-    actionPromiseService,
-    gettext,
-    $qExtensions,
-    waitSpinner,
-    instanceResourceType
-  ) {
-    var policyPromise;
+  function factory(nova, simpleService) {
 
-    var service = {
-      initScope: initScope,
-      allowed: allowed,
-      perform: perform
-    };
-
-    return service;
-
-    //////////////
-
-    function initScope() {
-      policyPromise = policy.ifAllowed({rules: [['instance', 'unpause_instance']]});
+    var config = {
+      rules: [['instance', 'unpause_instance']],
+      execute: execute,
+      validState: validState
     }
 
-    function perform(item) {
-      waitSpinner.showModalSpinner(gettext('Please Wait'));
-      return nova.unpauseServer(item.id).then(onSuccess, onFailure);
+    return simpleService(config);
 
-      function onSuccess() {
-        waitSpinner.hideModalSpinner();
-        return actionPromiseService.getResolved()
-          .updated(instanceResourceType, item.id)
-          .result;
-      }
-
-      function onFailure() {
-        waitSpinner.hideModalSpinner();
-      }
+    function execute(instance) {
+      return nova.unpauseServer(instance.id);
     }
 
-    function allowed(instance) {
-      return $q.all([
-        policyPromise,
-        userSessionService.isCurrentProject(instance.owner),
-        properState(instance)
-      ]);
-
-      function properState(instance) {
-        var proper = !instance.protected && instance.status === 'PAUSED';
-        return $qExtensions.booleanAsPromise(proper);
-      }
+    function validState(instance) {
+      return !instance.protected && instance.status === 'PAUSED';
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
@@ -1,4 +1,6 @@
 /**
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use self file except in compliance with the License. You may obtain
  * a copy of the License at

--- a/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
@@ -34,10 +34,10 @@
   function factory(nova, simpleService) {
 
     var config = {
-      rules: [['instance', 'unpause_instance']],
+      rules: [['compute', 'compute_extension:admin_actions:unpause']],
       execute: execute,
       validState: validState
-    }
+    };
 
     return simpleService(config);
 
@@ -46,7 +46,8 @@
     }
 
     function validState(instance) {
-      return !instance.protected && instance.status === 'PAUSED';
+      return !instance.protected && instance.status === 'PAUSED' &&
+        instance['OS-EXT-STS:task_state'] !== 'DELETING';
     }
   }
 })();

--- a/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
+++ b/openstack_dashboard/static/app/core/instances/actions/unpause.service.js
@@ -1,0 +1,110 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use self file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.app.core.instances')
+    .factory('horizon.app.core.instances.actions.unpause.service', factory);
+
+  factory.$inject = [
+    '$q',
+    'horizon.app.core.openstack-service-api.nova',
+    'horizon.app.core.openstack-service-api.userSession',
+    'horizon.app.core.openstack-service-api.policy',
+    'horizon.framework.util.i18n.gettext',
+    'horizon.framework.util.q.extensions',
+    'horizon.framework.widgets.modal-wait-spinner.service',
+    'horizon.app.core.instances.resourceType'
+  ];
+
+  /**
+   * @ngDoc factory
+   * @name horizon.app.core.instances.actions.delete-instance.service
+   *
+   * @Description
+   * Pauses the given server.
+   */
+  function factory(
+    $q,
+    nova,
+    userSessionService,
+    policy,
+    gettext,
+    $qExtensions,
+    waitSpinner,
+    instanceResourceType
+  ) {
+    var scope, policyPromise;
+
+    var service = {
+      initScope: initScope,
+      allowed: allowed,
+      perform: perform
+    };
+
+    return service;
+
+    //////////////
+
+    function initScope(newScope) {
+      scope = newScope;
+      policyPromise = policy.ifAllowed({rules: [['instance', 'unpause_instance']]});
+    }
+
+    function perform(item) {
+      waitSpinner.showModalSpinner(gettext('Please Wait'));
+      return nova.unpauseServer(item.id).then(onSuccess, onFailure);
+
+      function onSuccess() {
+      waitSpinner.hideModalSpinner();
+        return {
+          updated: [{type: instanceResourceType, id: item.id}],
+          deleted: [],
+          created: [],
+          deleted: []
+        };
+      }
+    }
+
+    function allowed(instance) {
+      // only row actions pass in instance
+      // otherwise, assume it is a batch action
+      if (instance) {
+        return $q.all([
+          notProtected(instance),
+          policyPromise,
+          userSessionService.isCurrentProject(instance.owner),
+          properState(instance)
+        ]);
+      }
+      else {
+        return policy.ifAllowed({ rules: [['instance', 'unpause_instance']] });
+      }
+    }
+
+    function onFailure() {
+      waitSpinner.hideModalSpinner();
+    }
+
+    function properState(instance) {
+      return $qExtensions.booleanAsPromise(instance.status === 'PAUSED');
+    }
+
+    function notProtected(instance) {
+      return $qExtensions.booleanAsPromise(!instance.protected);
+    }
+  }
+})();

--- a/openstack_dashboard/static/app/core/instances/instances.module.js
+++ b/openstack_dashboard/static/app/core/instances/instances.module.js
@@ -70,7 +70,7 @@
         id: 'name',
         priority: 1,
         sortDefault: true,
-        template: '<a ng-href="{$ \'details/OS::Nova::Server/\' + item.id $}">{$ item.name $}</a>'
+        template: '<a ng-href="{$ \'project/ngdetails/OS::Nova::Server/\' + item.id $}">{$ item.name $}</a>'
       })
       .append({
         id: 'image_name',

--- a/openstack_dashboard/static/app/core/networks/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/networks/actions/actions.module.js
@@ -19,40 +19,27 @@
 
   /**
    * @ngdoc overview
-   * @ngname horizon.app.core.instances.actions
+   * @ngname horizon.app.core.networks.actions
    *
    * @description
-   * Provides all of the actions for instances.
+   * Provides all of the actions for networks.
    */
-  angular.module('horizon.app.core.instances.actions',
-    ['horizon.framework.conf', 'horizon.app.core'])
+  angular.module('horizon.app.core.networks.actions',
+    ['horizon.framework.conf', 'horizon.app.core', 'horizon.framework.util.actions'])
     .run(run);
 
   run.$inject = [
     'horizon.framework.conf.resource-type-registry.service',
     'horizon.framework.util.actions.redirect-action.service',
-    'horizon.app.core.images.actions.launch-instance.service',
-    'horizon.app.core.instances.actions.delete-instance.service',
-    'horizon.app.core.instances.resourceType'
+    'horizon.app.core.networks.resourceType'
   ];
 
   function run(
     registry,
     redirectService,
-    launchInstanceService,
-    deleteService,
-    instanceResourceTypeCode)
+    resourceType)
   {
-    var instanceResourceType = registry.getResourceType(instanceResourceTypeCode);
-    instanceResourceType.globalActions
-      .append({
-        id: 'launchInstanceService',
-        service: launchInstanceService,
-        template: {
-          text: gettext('Create Instance')
-        }
-      });
-
+    var instanceResourceType = registry.getResourceType(resourceType);
     instanceResourceType.itemActions
       .append({
         id: 'legacyService',
@@ -60,19 +47,11 @@
         template: {
           text: gettext('Legacy Details...')
         }
-      })
-      .append({
-        id: 'deleteService',
-        service: deleteService,
-        template: {
-          text: gettext('Delete'),
-          type: "delete"
-        }
       });
 
-   function legacyPath(item) {
-     return 'project/instances/' + item.id + '/';
-   }
+    function legacyPath(item) {
+     return 'project/networks/' + item.id + '/detail';
+    }
   }
 
 })();

--- a/openstack_dashboard/static/app/core/networks/actions/actions.module.js
+++ b/openstack_dashboard/static/app/core/networks/actions/actions.module.js
@@ -1,0 +1,57 @@
+/**
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  /**
+   * @ngdoc overview
+   * @ngname horizon.app.core.networks.actions
+   *
+   * @description
+   * Provides all of the actions for networks.
+   */
+  angular.module('horizon.app.core.networks.actions',
+    ['horizon.framework.conf', 'horizon.app.core', 'horizon.framework.util.actions'])
+    .run(run);
+
+  run.$inject = [
+    'horizon.framework.conf.resource-type-registry.service',
+    'horizon.framework.util.actions.redirect-action.service',
+    'horizon.app.core.networks.resourceType'
+  ];
+
+  function run(
+    registry,
+    redirectService,
+    resourceType)
+  {
+    var instanceResourceType = registry.getResourceType(resourceType);
+    instanceResourceType.itemActions
+      .append({
+        id: 'legacyService',
+        service: redirectService(legacyPath),
+        template: {
+          text: gettext('Legacy Details...')
+        }
+      });
+
+    function legacyPath(item) {
+     return 'project/networks/' + item.id + '/detail';
+    }
+  }
+
+})();

--- a/openstack_dashboard/static/app/core/networks/details/details.module.js
+++ b/openstack_dashboard/static/app/core/networks/details/details.module.js
@@ -1,0 +1,53 @@
+/**
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  /**
+   * @ngdoc overview
+   * @ngname horizon.app.core.networks.details
+   *
+   * @description
+   * Provides details features for networks.
+   */
+  angular.module('horizon.app.core.networks.details',
+    ['horizon.framework.conf', 'horizon.app.core'])
+    .run(run);
+
+  run.$inject = [
+    'horizon.app.core.networks.resourceType',
+    'horizon.app.core.openstack-service-api.neutron',
+    'horizon.app.core.networks.basePath',
+    'horizon.framework.conf.resource-type-registry.service'
+  ];
+
+  function run(
+    resourceType,
+    neutronApi,
+    basePath,
+    registry
+  ) {
+    registry.getResourceType(resourceType)
+      .setLoadFunction(loadFunction)
+      .setDrawerTemplateUrl(basePath + 'details/drawer.html');
+
+    function loadFunction(identifier) {
+      return neutronApi.getNetwork(identifier);
+    }
+  }
+
+})();

--- a/openstack_dashboard/static/app/core/networks/details/drawer.html
+++ b/openstack_dashboard/static/app/core/networks/details/drawer.html
@@ -1,0 +1,10 @@
+<div class="row">
+  <div class="col-md-6">
+    <dl class="dl-horizontal">
+    </dl>
+  </div>
+  <div class="col-md-6">
+    <dl class="dl-horizontal">
+    </dl>
+  </div>
+</div>

--- a/openstack_dashboard/static/app/core/networks/networks.module.js
+++ b/openstack_dashboard/static/app/core/networks/networks.module.js
@@ -1,0 +1,53 @@
+/**
+ * (c) Copyright 2015 Hewlett-Packard Development Company, L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function() {
+  'use strict';
+
+  /**
+   * @ngdoc overview
+   * @ngname horizon.app.core.networks
+   *
+   * @description
+   * Provides all of the services and widgets required
+   * to support and display network related content.
+   */
+  angular
+    .module('horizon.app.core.networks', ['ngRoute',
+      'horizon.app.core.networks.actions', 'horizon.app.core.networks.details'])
+    .constant('horizon.app.core.networks.resourceType', 'OS::Neutron::Net')
+    .config(config)
+    .run(run);
+
+  config.$inject = [ '$provide', '$windowProvider' ];
+
+  function config($provide, $windowProvider) {
+    var path = $windowProvider.$get().STATIC_URL + 'app/core/networks/';
+    $provide.constant('horizon.app.core.networks.basePath', path);
+  }
+
+  run.$inject = [
+    'horizon.framework.conf.resource-type-registry.service',
+    'horizon.app.core.networks.resourceType'
+  ];
+
+  function run(registry, resourceType) {
+    registry.getResourceType(resourceType, {
+      names: [gettext('Network'), gettext('Networks')]
+    });
+  }
+
+})();

--- a/openstack_dashboard/static/app/core/openstack-service-api/nova.service.js
+++ b/openstack_dashboard/static/app/core/openstack-service-api/nova.service.js
@@ -269,6 +269,16 @@
       });
     }
 
+    function serverStateOperation(operation, serverId, suppressError, errMsg) {
+      var instruction = {"operation": operation};
+      var promise = apiService.post('/api/nova/servers/' + serverId, instruction);
+
+      return suppressError ? promise : promise.error(function() {
+        toastService.add('error', interpolate(errMsg, { id: serverId }, true));
+      });
+
+    }
+
     /**
      * @name startServer
      * @description
@@ -279,13 +289,8 @@
      * @returns {Object} The result of the API call
      */
     function startServer(serverId, suppressError) {
-      var operation = {"operation": "start"};
-      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
-
-      return suppressError ? promise : promise.error(function() {
-        var msg = gettext('Unable to start the server with id: %(id)s');
-        toastService.add('error', interpolate(msg, { id: serverId }, true));
-      });
+      return serverStateOperation('start', serverId, suppressError,
+        gettext('Unable to start the server with id: %(id)s'));
     }
 
     /**
@@ -298,13 +303,8 @@
      * @returns {Object} The result of the API call
      */
     function pauseServer(serverId, suppressError) {
-      var operation = {"operation": "pause"};
-      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
-
-      return suppressError ? promise : promise.error(function() {
-        var msg = gettext('Unable to pause the server with id: %(id)s');
-        toastService.add('error', interpolate(msg, { id: serverId }, true));
-      });
+      return serverStateOperation('pause', serverId, suppressError,
+        gettext('Unable to pause the server with id: %(id)s'));
     }
 
     /**
@@ -317,13 +317,8 @@
      * @returns {Object} The result of the API call
      */
     function unpauseServer(serverId, suppressError) {
-      var operation = {"operation": "unpause"};
-      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
-
-      return suppressError ? promise : promise.error(function() {
-        var msg = gettext('Unable to unpause the server with id: %(id)s');
-        toastService.add('error', interpolate(msg, { id: serverId }, true));
-      });
+      return serverStateOperation('unpause', serverId, suppressError,
+        gettext('Unable to un-pause the server with id: %(id)s'));
     }
 
     /**
@@ -336,13 +331,8 @@
      * @returns {Object} The result of the API call
      */
     function suspendServer(serverId, suppressError) {
-      var operation = {"operation": "suspend"};
-      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
-
-      return suppressError ? promise : promise.error(function() {
-        var msg = gettext('Unable to suspend the server with id: %(id)s');
-        toastService.add('error', interpolate(msg, { id: serverId }, true));
-      });
+      return serverStateOperation('suspend', serverId, suppressError,
+        gettext('Unable to suspend the server with id: %(id)s'));
     }
 
     /**
@@ -355,13 +345,8 @@
      * @returns {Object} The result of the API call
      */
     function resumeServer(serverId, suppressError) {
-      var operation = {"operation": "resume"};
-      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
-
-      return suppressError ? promise : promise.error(function() {
-        var msg = gettext('Unable to resume the server with id: %(id)s');
-        toastService.add('error', interpolate(msg, { id: serverId }, true));
-      });
+      return serverStateOperation('resume', serverId, suppressError,
+        gettext('Unable to resume the server with id: %(id)s'));
     }
 
     /**
@@ -374,13 +359,8 @@
      * @returns {Object} The result of the API call
      */
     function softRebootServer(serverId, suppressError) {
-      var operation = {"operation": "soft_reboot"};
-      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
-
-      return suppressError ? promise : promise.error(function() {
-        var msg = gettext('Unable to reboot the server with id: %(id)s');
-        toastService.add('error', interpolate(msg, { id: serverId }, true));
-      });
+      return serverStateOperation('soft_reboot', serverId, suppressError,
+        gettext('Unable to reboot the server with id: %(id)s'));
     }
 
     /**
@@ -393,13 +373,8 @@
      * @returns {Object} The result of the API call
      */
     function hardRebootServer(serverId, suppressError) {
-      var operation = {"operation": "hard_reboot"};
-      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
-
-      return suppressError ? promise : promise.error(function() {
-        var msg = gettext('Unable to reboot the server with id: %(id)s');
-        toastService.add('error', interpolate(msg, { id: serverId }, true));
-      });
+      return serverStateOperation('hard_reboot', serverId, suppressError,
+        gettext('Unable to reboot the server with id: %(id)s'));
     }
 
     /**
@@ -412,13 +387,8 @@
      * @returns {Object} The result of the API call
      */
     function stopServer(serverId, suppressError) {
-      var operation = {"operation": "stop"};
-      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
-
-      return suppressError ? promise : promise.error(function() {
-        var msg = gettext('Unable to stop the server with id: %(id)s');
-        toastService.add('error', interpolate(msg, { id: serverId }, true));
-      });
+      return serverStateOperation('stop', serverId, suppressError,
+        gettext('Unable to stop the server with id: %(id)s'));
     }
 
     /**

--- a/openstack_dashboard/static/app/core/openstack-service-api/nova.service.js
+++ b/openstack_dashboard/static/app/core/openstack-service-api/nova.service.js
@@ -47,6 +47,8 @@
       getServer: getServer,
       getServers: getServers,
       deleteServer: deleteServer,
+      startServer: startServer,
+      stopServer: stopServer,
       getExtensions: getExtensions,
       getFlavors: getFlavors,
       getFlavor: getFlavor,
@@ -257,6 +259,44 @@
 
       return suppressError ? promise : promise.error(function() {
         var msg = gettext('Unable to delete the server with id: %(id)s');
+        toastService.add('error', interpolate(msg, { id: serverId }, true));
+      });
+    }
+
+    /**
+     * @name startServer
+     * @description
+     * Start a single server by ID.
+     *
+     * @param {String} serverId
+     * Server to start
+     * @returns {Object} The result of the API call
+     */
+    function startServer(serverId, suppressError) {
+      var operation = {"operation": "start"};
+      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
+
+      return suppressError ? promise : promise.error(function() {
+        var msg = gettext('Unable to start the server with id: %(id)s');
+        toastService.add('error', interpolate(msg, { id: serverId }, true));
+      });
+    }
+
+    /**
+     * @name stopServer
+     * @description
+     * Stop a single server by ID.
+     *
+     * @param {String} serverId
+     * Server to stop
+     * @returns {Object} The result of the API call
+     */
+    function stopServer(serverId, suppressError) {
+      var operation = {"operation": "stop"};
+      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
+
+      return suppressError ? promise : promise.error(function() {
+        var msg = gettext('Unable to stop the server with id: %(id)s');
         toastService.add('error', interpolate(msg, { id: serverId }, true));
       });
     }

--- a/openstack_dashboard/static/app/core/openstack-service-api/nova.service.js
+++ b/openstack_dashboard/static/app/core/openstack-service-api/nova.service.js
@@ -49,6 +49,8 @@
       deleteServer: deleteServer,
       pauseServer: pauseServer,
       unpauseServer: unpauseServer,
+      suspendServer: suspendServer,
+      resumeServer: resumeServer,
       startServer: startServer,
       stopServer: stopServer,
       getExtensions: getExtensions,
@@ -322,6 +324,43 @@
       });
     }
 
+    /**
+     * @name suspendServer
+     * @description
+     * Suspend a single server by ID.
+     *
+     * @param {String} serverId
+     * Server to suspend
+     * @returns {Object} The result of the API call
+     */
+    function suspendServer(serverId, suppressError) {
+      var operation = {"operation": "suspend"};
+      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
+
+      return suppressError ? promise : promise.error(function() {
+        var msg = gettext('Unable to suspend the server with id: %(id)s');
+        toastService.add('error', interpolate(msg, { id: serverId }, true));
+      });
+    }
+
+    /**
+     * @name resumeServer
+     * @description
+     * Resumes a single server by ID.
+     *
+     * @param {String} serverId
+     * Server to resume
+     * @returns {Object} The result of the API call
+     */
+    function resumeServer(serverId, suppressError) {
+      var operation = {"operation": "resume"};
+      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
+
+      return suppressError ? promise : promise.error(function() {
+        var msg = gettext('Unable to resume the server with id: %(id)s');
+        toastService.add('error', interpolate(msg, { id: serverId }, true));
+      });
+    }
     /**
      * @name stopServer
      * @description

--- a/openstack_dashboard/static/app/core/openstack-service-api/nova.service.js
+++ b/openstack_dashboard/static/app/core/openstack-service-api/nova.service.js
@@ -47,6 +47,8 @@
       getServer: getServer,
       getServers: getServers,
       deleteServer: deleteServer,
+      pauseServer: pauseServer,
+      unpauseServer: unpauseServer,
       startServer: startServer,
       stopServer: stopServer,
       getExtensions: getExtensions,
@@ -278,6 +280,44 @@
 
       return suppressError ? promise : promise.error(function() {
         var msg = gettext('Unable to start the server with id: %(id)s');
+        toastService.add('error', interpolate(msg, { id: serverId }, true));
+      });
+    }
+
+    /**
+     * @name pauseServer
+     * @description
+     * Pause a single server by ID.
+     *
+     * @param {String} serverId
+     * Server to pause
+     * @returns {Object} The result of the API call
+     */
+    function pauseServer(serverId, suppressError) {
+      var operation = {"operation": "pause"};
+      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
+
+      return suppressError ? promise : promise.error(function() {
+        var msg = gettext('Unable to pause the server with id: %(id)s');
+        toastService.add('error', interpolate(msg, { id: serverId }, true));
+      });
+    }
+
+    /**
+     * @name unpauseServer
+     * @description
+     * Un-Pause a single server by ID.
+     *
+     * @param {String} serverId
+     * Server to unpause
+     * @returns {Object} The result of the API call
+     */
+    function unpauseServer(serverId, suppressError) {
+      var operation = {"operation": "unpause"};
+      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
+
+      return suppressError ? promise : promise.error(function() {
+        var msg = gettext('Unable to unpause the server with id: %(id)s');
         toastService.add('error', interpolate(msg, { id: serverId }, true));
       });
     }

--- a/openstack_dashboard/static/app/core/openstack-service-api/nova.service.js
+++ b/openstack_dashboard/static/app/core/openstack-service-api/nova.service.js
@@ -51,6 +51,8 @@
       unpauseServer: unpauseServer,
       suspendServer: suspendServer,
       resumeServer: resumeServer,
+      softRebootServer: softRebootServer,
+      hardRebootServer: hardRebootServer,
       startServer: startServer,
       stopServer: stopServer,
       getExtensions: getExtensions,
@@ -361,6 +363,45 @@
         toastService.add('error', interpolate(msg, { id: serverId }, true));
       });
     }
+
+    /**
+     * @name softRebootServer
+     * @description
+     * Soft-reboots a single server by ID.
+     *
+     * @param {String} serverId
+     * Server to reboot
+     * @returns {Object} The result of the API call
+     */
+    function softRebootServer(serverId, suppressError) {
+      var operation = {"operation": "soft_reboot"};
+      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
+
+      return suppressError ? promise : promise.error(function() {
+        var msg = gettext('Unable to reboot the server with id: %(id)s');
+        toastService.add('error', interpolate(msg, { id: serverId }, true));
+      });
+    }
+
+    /**
+     * @name hardRebootServer
+     * @description
+     * Hard-reboots a single server by ID.
+     *
+     * @param {String} serverId
+     * Server to reboot
+     * @returns {Object} The result of the API call
+     */
+    function hardRebootServer(serverId, suppressError) {
+      var operation = {"operation": "hard_reboot"};
+      var promise = apiService.post('/api/nova/servers/' + serverId, operation);
+
+      return suppressError ? promise : promise.error(function() {
+        var msg = gettext('Unable to reboot the server with id: %(id)s');
+        toastService.add('error', interpolate(msg, { id: serverId }, true));
+      });
+    }
+
     /**
      * @name stopServer
      * @description


### PR DESCRIPTION
This patch provides basic item-level start/stop server functionality.  It doesn't provide confirmation views, and it seems that the actions are not updating properly, but that is not the fault of this patch.
